### PR TITLE
docs: Update Development Guide link and Go version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project demonstrates a dynamic validation system where:
 
 * Docker and Docker Compose
 * Node.js 20+ (for local development)
-* Go 1.21+ (for local development)
+* Go 1.24+ (for local development)
 * [Buf CLI](https://docs.buf.build/installation) (for proto code generation)
 
 ### Setup
@@ -52,7 +52,7 @@ docker compose ps
 
 ### For Developers
 
-* **[Developer Guide](docs/DEVELOPER_GUIDE.md)** - Setup, Git hooks, coding conventions, and contribution workflow
+* **[Development Guide](DEVELOPMENT.md)** - Setup, Git hooks, coding conventions, and contribution workflow
 
 ### Design Documentation
 


### PR DESCRIPTION
## Summary
Update README to reflect recent documentation changes:
- Development Guide moved to repository root (DEVELOPMENT.md)
- Go version requirement updated to 1.24+

## Changes
- Update Development Guide link: docs/DEVELOPER_GUIDE.md → DEVELOPMENT.md
- Update Go version: 1.21+ → 1.24+
- Update text: "Developer Guide" → "Development Guide"

## Related
- Follow-up to PR #25 and #26

🤖 Generated with Claude Code