### PR TITLE
docs: Update PoC scope - Focus on protovalidate + Context Enrichment

### DIFF
--- a/.github/git-hooks/pre-push
+++ b/.github/git-hooks/pre-push
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "Running markdown lint..."
+npm run lint:md
+
+if [ $? -ne 0 ]; then
+    echo -e "\033[31mError: Markdown lint failed. Please fix the errors above.\033[0m"
+    echo -e "\033[33mTip: Run 'npm run lint:md:fix' to auto-fix some issues.\033[0m"
+    exit 1
+fi
+
+echo -e "\033[32mMarkdown lint passed!\033[0m"
+exit 0

--- a/.github/git-hooks/setup-hooks.sh
+++ b/.github/git-hooks/setup-hooks.sh
@@ -3,9 +3,7 @@ set -euo pipefail
 
 # Determine paths based on script location
 SCRIPT_DIR=$(dirname "$0")
-HOOK_SOURCE="$SCRIPT_DIR/commit-msg"
 HOOKS_DIR=$(git rev-parse --git-path hooks)
-HOOK_DEST="$HOOKS_DIR/commit-msg"
 
 echo "Configuring git hooks from .github/git-hooks/..."
 
@@ -15,22 +13,34 @@ if ! git rev-parse --git-dir >/dev/null 2>&1; then
     exit 1
 fi
 
-# Check if source hook file exists
-if [ ! -f "$HOOK_SOURCE" ]; then
-    echo "Error: Hook source file not found at $HOOK_SOURCE"
-    exit 1
-fi
+# Function to install a hook
+install_hook() {
+    local hook_name=$1
+    local hook_source="$SCRIPT_DIR/$hook_name"
+    local hook_dest="$HOOKS_DIR/$hook_name"
 
-# Copy hook file and make it executable
-if ! cp "$HOOK_SOURCE" "$HOOK_DEST"; then
-    echo "Error: Failed to copy hook to $HOOK_DEST"
-    exit 1
-fi
+    # Check if source hook file exists
+    if [ ! -f "$hook_source" ]; then
+        echo "Warning: Hook source file not found at $hook_source, skipping..."
+        return 0
+    fi
 
-if ! chmod +x "$HOOK_DEST"; then
-    echo "Error: Failed to make hook executable"
-    exit 1
-fi
+    # Copy hook file and make it executable
+    if ! cp "$hook_source" "$hook_dest"; then
+        echo "Error: Failed to copy $hook_name to $hook_dest"
+        return 1
+    fi
 
-echo "Successfully installed commit-msg hook to $HOOK_DEST"
+    if ! chmod +x "$hook_dest"; then
+        echo "Error: Failed to make $hook_name executable"
+        return 1
+    fi
+
+    echo "Successfully installed $hook_name hook to $hook_dest"
+    return 0
+}
+
+# Install hooks
+install_hook "commit-msg"
+install_hook "pre-push"
 

--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,2 @@
+node_modules/
+__private/

--- a/README.md
+++ b/README.md
@@ -56,11 +56,13 @@ go run main.go
 # -> http://localhost:50052 で起動
 
 # 3. (Optional) Start FE service (実装後)
+# 別ターミナルで実行:
 cd services/fe
 npm run dev
 # -> http://localhost:3000 で起動
 
 # 4. (Optional) Start ISR service (参考)
+# 別ターミナルで実行:
 cd services/isr
 go run main.go
 # -> http://localhost:50051 で起動
@@ -242,7 +244,7 @@ building-a-schema-first-dynamic-validation-system/
 └── docs/                # Design documentation
 ```
 
-**注**: `docker-compose.yml` と `docker/init-db/` は削除されました（PostgreSQL 不要のため）
+**注**: `docker-compose.yml` と `docker/init-db/` は今後削除予定です（PostgreSQL 不要のため）
 
 ## PoC Verification Scenarios
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,48 @@
 # Building a Schema-First Dynamic Validation System
 
-A proof-of-concept for a schema-first dynamic validation system using ConnectRPC and protovalidate, ensuring seamless contract synchronization across FE, BFF, and BE.
+A proof-of-concept for schema-first validation using ConnectRPC and protovalidate, demonstrating **protovalidate-based validation** and **Context Enrichment** across FE and BE.
 
 ## Overview
 
-This project demonstrates a schema-first validation system where:
+This PoC focuses on validating the core concepts of schema-driven validation:
 
-* `.proto` files serve as the single source of truth for validation rules
-* Business logic (e.g., user plan-based restrictions) is enforced consistently across all layers using CEL expressions
-* **Note**: Runtime schema updates without restarts (hot reload) were explored but found to be incompatible with protovalidate's static message validation architecture. See [Validation Strategy § 7.1](docs/001-DD.003.validation-strategy.md#71-実装結果と重要な制約事項) for details.
+* `.proto` files serve as the **single source of truth** for validation rules
+* **Context Enrichment**: Business logic (user plan-based restrictions) using永続層の値
+* **protovalidate**: Declarative validation rules using CEL expressions
+* **FE/BE validation**: Both layers use protovalidate for consistent validation
 
-## Architecture
+### What this PoC demonstrates
 
-* **Frontend**: TypeScript, React, `@connectrpc/connect-web`
-* **Backend**: Go, `connect-go`, `protovalidate-go`
-* **ISR (Internal Schema Registry)**: Go service for schema distribution
-* **Database**: PostgreSQL (with separate databases for ISR and backend)
+✅ **protovalidate** による宣言的バリデーション
+✅ **Context Enrichment** (YAML から user.plan を取得して動的バリデーション)
+✅ FE/BE 両方での protovalidate 動作確認
+✅ curl/grpcurl による API 検証
+
+### What is out of scope
+
+❌ Hot Reload (技術的制約により実現不可 - [詳細](docs/001-DD.003.validation-strategy.md#71-実装結果と重要な制約事項))
+❌ 動的スキーマ配信・同期機構
+❌ FE-BE 間の実際の通信 (各層で独立してバリデーション検証)
+❌ Server Streaming
+❌ E2Eテスト (Playwright)
+
+## Architecture (Simplified)
+
+* **Backend**: Go, `connect-go`, `protovalidate-go`, YAML 永続化
+* **Frontend**: TypeScript, `protovalidate-ts`, YAML 永続化（疑似的な実装）
+* **ISR**: Go service (参考実装として維持、BE との連携なし)
+* **Persistence**: YAML ファイル (PostgreSQL は使用しない)
+* **Services**: 個別起動 (docker-compose は使用しない)
 
 ## Getting Started
 
 ### Prerequisites
 
-* Docker and Docker Compose
-* Node.js 20+ (for local development)
-* Go 1.24+ (for local development)
-* [Buf CLI](https://docs.buf.build/installation) (for proto code generation)
+* Node.js 20+ (FE 開発用)
+* Go 1.24+ (BE 開発用)
+* [Buf CLI](https://docs.buf.build/installation) (proto コード生成用)
+
+**注**: docker-compose は不要です（サービス間の依存関係がないため）
 
 ### Setup
 
@@ -32,47 +50,130 @@ This project demonstrates a schema-first validation system where:
 # 1. Generate code from proto files
 make proto-generate
 
-# 2. Start services
-docker compose up -d
+# 2. Start BE service
+cd services/be
+go run main.go
+# -> http://localhost:50052 で起動
 
-# 3. Check service status
-docker compose ps
+# 3. (Optional) Start FE service (実装後)
+cd services/fe
+npm run dev
+# -> http://localhost:3000 で起動
 
-# 4. Upload initial schema
-./scripts/upload-schema.sh 1.0.0
+# 4. (Optional) Start ISR service (参考)
+cd services/isr
+go run main.go
+# -> http://localhost:50051 で起動
 ```
 
-### Connection Information
+### YAML Persistence
 
-* **Container-to-container**: Use service names (e.g., `db:5432`, `isr:50051`)
-* **Host-to-container**: Use `localhost` with fixed ports (e.g., `localhost:5432`)
+データは YAML ファイルに保存されます:
+
+```bash
+services/be/data/
+├── user.yaml    # ユーザー情報
+└── post.yaml    # 投稿情報
+
+services/fe/data/  # (実装後)
+├── user.yaml
+└── post.yaml
+```
+
+### API Testing
+
+#### curl (HTTP/JSON)
+
+```bash
+# Create User
+curl -X POST http://localhost:50052/user.v1.UserService/CreateUser \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "plan": "USER_PLAN_PRO"
+  }'
+
+# List Users
+curl -X POST http://localhost:50052/user.v1.UserService/ListUsers \
+  -H "Content-Type: application/json" \
+  -d '{"page": 1, "pageSize": 10}'
+```
+
+#### grpcurl (gRPC)
+
+```bash
+# Create User
+grpcurl -plaintext \
+  -d '{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "plan": "USER_PLAN_PRO"
+  }' \
+  localhost:50052 \
+  user.v1.UserService/CreateUser
+
+# List Users
+grpcurl -plaintext \
+  -d '{"page": 1, "pageSize": 10}' \
+  localhost:50052 \
+  user.v1.UserService/ListUsers
+```
 
 ## Documentation
 
 ### For Developers
 
-* **[Development Guide](DEVELOPMENT.md)** - Setup, Git hooks, coding conventions, and contribution workflow
+* **[Development Guide](DEVELOPMENT.md)** - Setup, Git hooks, coding conventions
 
 ### Design Documentation
 
-Detailed design documentation is available in the `docs/` directory:
-
-* [Requirements](docs/000.requirement.md) - Project goals and PoC scenarios
-* [High-Level Design](docs/001-DD.001.high-level-design.md) - Overall architecture
-* [Schema Management](docs/001-DD.002.schema-management-and-distribution.md) - SemVer strategy and distribution
-* [Validation Strategy](docs/001-DD.003.validation-strategy.md) - Context enrichment pattern
-* [Data Model](docs/001-DD.004.data-model-and-api-interface.md) - Database schema and API interface
-* [Implementation Guidelines](docs/001-DD.005.other.md) - Error handling and observability
-* [Monorepo Structure](docs/001-DD.006.monorepo.md) - Project layout and dependencies
+* [Requirements](docs/000.requirement.md) - PoC の目的とスコープ（更新済み）
+* [High-Level Design](docs/001-DD.001.high-level-design.md) - 簡略化されたアーキテクチャ（更新済み）
+* [Validation Strategy](docs/001-DD.003.validation-strategy.md) - Context Enrichment パターン
+* [Data Model (YAML)](docs/001-DD.004.data-model-and-api-interface.md) - YAML フォーマットと API（更新済み）
+* [Tasks](docs/003-TASK.001.tasks.md) - タスク一覧（更新済み）
 
 ## Key Features
 
-1. **Schema-First Architecture**: Single source of truth for validation rules and API contracts
-2. **Dual-Layer Validation**: Optimistic validation in FE, authoritative validation in BE
-3. **Context Enrichment**: Business rules (user plans) injected into proto messages for CEL-based validation
-4. **Schema Registry (ISR)**: Centralized schema versioning and distribution
+### 1. Schema-First Validation
 
-**Note on Hot Reload**: While the ISR infrastructure supports schema versioning and polling, runtime validation rule updates without restarts are not possible with protovalidate's static message architecture. Schema updates require rebuilding and redeploying services. See [Design Doc § 7.1](docs/001-DD.003.validation-strategy.md#71-実装結果と重要な制約事項) for technical details and recommended deployment strategies.
+`.proto` ファイルに定義された validation ルールが FE/BE で自動的に適用されます:
+
+```protobuf
+message CreateUserRequest {
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1,
+    max_len: 100
+  }];
+  string email = 2 [(buf.validate.field).string.email = true];
+  common.v1.UserPlan plan = 3;
+}
+```
+
+### 2. Context Enrichment
+
+BE では YAML から user.plan を取得し、plan に応じた動的バリデーションを実現:
+
+* **free**: message は 100文字以内
+* **pro**: message は 200文字以内
+* **enterprise**: message は 300文字以内
+
+```go
+// user.yaml から User を取得
+user, err := h.userRepo.GetByID(ctx, req.Msg.UserId)
+
+// user.plan に基づいて message の長さを検証
+maxLen := getMaxLengthForPlan(user.Plan)
+if len(req.Msg.Message) > maxLen {
+    return connect.NewError(connect.CodeInvalidArgument, ...)
+}
+```
+
+### 3. Dual-Layer Validation
+
+* **FE**: protovalidate-ts で即時バリデーション（ユーザー体験向上）
+* **BE**: protovalidate-go で最終バリデーション（セキュリティ保証）
 
 ## Development
 
@@ -98,38 +199,8 @@ make fmt
 # Lint code
 make lint
 
-# Run all CI checks (lint, format, test)
+# Run all CI checks
 make ci
-```
-
-### Docker Commands
-
-```bash
-# Start all services
-make docker-up
-
-# Stop all services
-make docker-down
-
-# View logs
-make docker-logs
-
-# Clean up (remove volumes)
-make docker-clean
-```
-
-### Schema Management
-
-```bash
-# Upload schema to ISR
-./scripts/upload-schema.sh 1.0.0
-
-# Pull latest schema from ISR
-./scripts/pull-schema.sh 1 0
-
-# Or use make targets
-make schema-upload VERSION=1.0.0
-make schema-pull MAJOR=1 MINOR=0
 ```
 
 ### Linting
@@ -145,13 +216,12 @@ npm run lint:md:fix
 ### Project Structure
 
 ```text
-celo/
+building-a-schema-first-dynamic-validation-system/
 ├── go.work              # Go Workspaces configuration
 ├── package.json         # Node.js Workspaces configuration
 ├── buf.yaml             # Buf configuration
 ├── buf.gen.yaml         # Code generation settings
 ├── Makefile             # Common development tasks
-├── docker-compose.yml   # Service orchestration
 ├── proto/               # Proto definitions (single source of truth)
 │   ├── common/v1/
 │   ├── user/v1/
@@ -162,13 +232,37 @@ celo/
 │       ├── go/
 │       └── ts/
 ├── services/
-│   ├── isr/             # Internal Schema Registry
 │   ├── be/              # Backend service
-│   └── fe/              # Frontend
-├── docker/init-db/      # Database initialization scripts
-└── tests/
-    └── e2e/             # End-to-end tests
+│   │   ├── main.go
+│   │   ├── internal/
+│   │   └── data/        # YAML files
+│   ├── fe/              # Frontend (実装中)
+│   │   └── data/        # YAML files
+│   └── isr/             # ISR (参考実装)
+└── docs/                # Design documentation
 ```
+
+**注**: `docker-compose.yml` と `docker/init-db/` は削除されました（PostgreSQL 不要のため）
+
+## PoC Verification Scenarios
+
+### Scenario 1: Basic Validation
+
+1. User を作成
+2. protovalidate が name, email をバリデーション
+3. user.yaml に保存
+
+### Scenario 2: Context Enrichment
+
+1. free ユーザーで 100文字以内の Post を作成 → 成功
+2. free ユーザーで 101文字の Post を作成 → エラー
+3. pro ユーザーで 200文字以内の Post を作成 → 成功
+
+### Scenario 3: Security (plan 偽装の防御)
+
+1. リクエストで plan を偽装
+2. BE が user.yaml から正しい plan を取得
+3. 正しい plan でバリデーション → 偽装を検知してエラー
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ This PoC focuses on validating the core concepts of schema-driven validation:
 
 ### Setup
 
+**注**: 現状の BE 実装は PostgreSQL ベースのため、YAML 永続化への移行（Task 3-3）完了後に以下の手順が有効になります。現時点では `docker-compose up -d` または `CELO_DB_URL` 環境変数の設定が必要です。
+
 ```bash
 # 1. Generate code from proto files
 make proto-generate
 
-# 2. Start BE service
+# 2. Start BE service (YAML 永続化移行後)
 cd services/be
 go run main.go
 # -> http://localhost:50052 で起動

--- a/docs/000.requirement.md
+++ b/docs/000.requirement.md
@@ -25,15 +25,18 @@ A proof-of-concept for schema-first validation using ConnectRPC and protovalidat
 ## 2. システムアーキテクチャ（簡略版）
 
 ### 通信プロトコル
+
 * Connect (gRPC互換、HTTP/1.1 JSONも利用可能)
 * BE: curl/grpcurl による検証
 
 ### 永続化
+
 * **YAML ベース** (PostgreSQL は使用しない)
 * user.yaml: ユーザー情報
 * post.yaml: 投稿情報
 
 ### サービス構成
+
 * **FE**: TypeScript、YAML永続化による疑似的な実装
 * **BE**: Go、YAMLから読み取り、Context Enrichment を実装
 * **ISR**: 既存実装を維持（参考実装として残す）
@@ -62,12 +65,14 @@ A proof-of-concept for schema-first validation using ConnectRPC and protovalidat
 ### C. 各層の責務
 
 #### 1. FE (TypeScript)
+
 * ユーザー作成画面、投稿一覧・作成画面
 * `protovalidate-ts` でクライアント側バリデーション
 * YAML ファイルへの永続化（疑似的な実装）
 * **実際のBE通信は行わない**（バリデーション検証に集中）
 
 #### 2. BE (Go)
+
 * User API: CreateUser, ListUsers
 * Post API: CreatePost, ListPosts
 * **Context Enrichment**: YAMLから user.plan を取得し、リクエストに注入してバリデーション

--- a/docs/000.requirement.md
+++ b/docs/000.requirement.md
@@ -31,9 +31,11 @@ A proof-of-concept for schema-first validation using ConnectRPC and protovalidat
 
 ### 永続化
 
-* **YAML ベース** (PostgreSQL は使用しない)
+* **YAML ベース** (PostgreSQL は使用しない - Task 3-3 で移行予定)
 * user.yaml: ユーザー情報
 * post.yaml: 投稿情報
+
+**注**: 現状の実装は PostgreSQL を使用しています。YAML 永続化への移行は Task 3-3 で実施予定です。
 
 ### サービス構成
 
@@ -123,16 +125,20 @@ A proof-of-concept for schema-first validation using ConnectRPC and protovalidat
 
 各サービスは個別に起動します（docker-compose は使用しません）:
 
+**注**: 現状の BE 実装は PostgreSQL ベースのため、YAML 永続化への移行（Task 3-3）完了後に以下の手順が有効になります。現時点では docker-compose または CELO_DB_URL の設定が必要です。
+
 ```bash
-# BE サービス
+# BE サービス（YAML 永続化移行後）
 cd services/be
 go run main.go
 
 # FE サービス（実装後）
+# 別ターミナルで実行:
 cd services/fe
 npm run dev
 
 # ISR サービス（参考）
+# 別ターミナルで実行:
 cd services/isr
 go run main.go
 ```

--- a/docs/000.requirement.md
+++ b/docs/000.requirement.md
@@ -1,60 +1,141 @@
 # Building a Schema-First Dynamic Validation System
 
-A proof-of-concept for a schema-first dynamic validation system using ConnectRPC and protovalidate, ensuring seamless contract synchronization across FE, BFF, and BE.
+A proof-of-concept for schema-first validation using ConnectRPC and protovalidate, demonstrating protovalidate-based validation and Context Enrichment across FE and BE.
 
 ## 1. プロジェクト目的
 
-* Single Source of Truth: `.proto`ファイルを唯一の正解とし、FE/BFF/BE全層でバリデーションロジックを同期する。
-* ~~Hot Reloading: アプリを再起動せず、実行時にスキーマ（バリデーションルール）を更新可能にする。~~ **[検証結果]** protovalidateの技術的制約により実現不可。詳細は[Design Doc 3 § 7.1](001-DD.003.validation-strategy.md#71-実装結果と重要な制約事項)参照。
-* Contract Programming: `protovalidate` (CEL) を用い、ユーザー属性（プラン）に応じた高度な相関バリデーションを宣言的に記述する。
+このPoCは、**protovalidate + Context Enrichment** による宣言的バリデーションの実現可能性を検証します。
 
-## 2. システムアーキテクチャ
+### 核心的な検証項目
 
-* 通信プロトコル: Connect (gRPC互換、HTTP/1.1 JSONを利用)
-* スキーマ管理: ISR (Internal Schema Registry) を中央レジストリとして利用
-* 配布モデル:
-  1. ローカルスクリプトで `descriptor.bin` をビルド・ISRにアップロード
-  2. ISR はスキーマをDBにキャッシュする
-  3. BE は ISR から最新の proto を取得して validator を更新
-  4. FE は BE から最新の proto を取得して validator を更新
+* **Single Source of Truth**: `.proto`ファイルを唯一の正解とし、FE/BE両層でバリデーションロジックを同期する。
+* **Context Enrichment**: 永続層（YAML）から取得した値（user.plan）を使った動的バリデーションを実現する。
+* **Contract Programming**: `protovalidate` (CEL) を用い、ユーザー属性（プラン）に応じた高度な相関バリデーションを宣言的に記述する。
+
+### スコープ外とした機能
+
+以下の機能はPoCの核心検証に不要なため、実装しません:
+
+* ~~Hot Reloading~~ - protovalidateの技術的制約により実現不可。詳細は[Design Doc 3 § 7.1](001-DD.003.validation-strategy.md#71-実装結果と重要な制約事項)参照。
+* ~~動的スキーマ配信・同期機構~~ - スキーマ駆動バリデーションの検証には不要
+* ~~FE-BE間の実際の通信~~ - protovalidateの動作検証には不要
+* ~~Server Streaming~~ - バリデーション検証には不要
+* ~~E2Eテスト (Playwright)~~ - スコープ外
+
+## 2. システムアーキテクチャ（簡略版）
+
+### 通信プロトコル
+* Connect (gRPC互換、HTTP/1.1 JSONも利用可能)
+* BE: curl/grpcurl による検証
+
+### 永続化
+* **YAML ベース** (PostgreSQL は使用しない)
+* user.yaml: ユーザー情報
+* post.yaml: 投稿情報
+
+### サービス構成
+* **FE**: TypeScript、YAML永続化による疑似的な実装
+* **BE**: Go、YAMLから読み取り、Context Enrichment を実装
+* **ISR**: 既存実装を維持（参考実装として残す）
+
+**注**: サービス間の依存関係がないため、docker-compose.yml は使用しません。各サービスは個別に起動します。
 
 ## 3. アプリケーション要件
 
 ### A. データモデル
 
-* User: `id` (UUID), `name` (1-10文字), `plan` (free | premium)
-* Post: `id` (UUID), `user_id` (UUID), `message` (string), `created_at` (timestamp)
+* **User**: `id` (UUID v7), `name` (1-100文字), `email`, `plan` (free | pro | enterprise)
+* **Post**: `id` (UUID v7), `user_id` (UUID v7), `message` (string), `created_at` (timestamp)
 
 ### B. バリデーションルール (CEL)
 
-* CreateUser: `name` の長さ制限。
-* CreatePost:
-* `free` ユーザー: `message` は 100文字以内。
-* `premium` ユーザー: `message` は 300文字以内。
-* ※BEではDBの値を優先し、メッセージを上書き補完した上で検証する。
+* **CreateUser**:
+  * `name` は 1-100文字
+  * `email` は有効なメールアドレス形式
+
+* **CreatePost**:
+  * `free` ユーザー: `message` は 100文字以内
+  * `pro` ユーザー: `message` は 200文字以内
+  * `enterprise` ユーザー: `message` は 300文字以内
+  * **重要**: BE では YAML から取得した user.plan を使って検証する（Context Enrichment）
 
 ### C. 各層の責務
 
-1. FE (TS):
-   * ログイン/新規登録、投稿一覧（Streaming受取）、新規投稿。
-   * メモリ上の `plan` を使い、文字入力のたびに 即時バリデーション（ボタンの活性/非活性制御）。
-   * BE からスキーマを定期取得し、protovalidate-ts でバリデーション。
+#### 1. FE (TypeScript)
+* ユーザー作成画面、投稿一覧・作成画面
+* `protovalidate-ts` でクライアント側バリデーション
+* YAML ファイルへの永続化（疑似的な実装）
+* **実際のBE通信は行わない**（バリデーション検証に集中）
 
-2. BE (Go):
-   * DB（PostgreSQL）から最新の `plan` を取得し、リクエストを補完して 最終バリデーション。
-   * 新着投稿を Server Streaming で配信。
-   * FE へのスキーマ配信エンドポイントを提供（ISR からの取得をプロキシ）。
+#### 2. BE (Go)
+* User API: CreateUser, ListUsers
+* Post API: CreatePost, ListPosts
+* **Context Enrichment**: YAMLから user.plan を取得し、リクエストに注入してバリデーション
+* `protovalidate-go` による宣言的バリデーション
+* curl/grpcurl による動作確認
 
-## 4. 技術スタック詳細
+## 4. 技術スタック
 
-* Frontend: TypeScript, React/Vue/Svelte, `@connectrpc/connect-web`, `protovalidate-ts`
-* Backend: Go, `connect-go`, `protovalidate-go`, `sqlx` (PostgreSQL)
-* ISR: Go, `connect-go`, PostgreSQL
-* Infrastructure: Docker Compose, PostgreSQL
+* **Frontend**: TypeScript, React/Vue/Svelte, `protovalidate-ts`
+* **Backend**: Go, `connect-go`, `protovalidate-go`
+* **永続化**: YAML ファイル
+* **通信プロトコル**: Connect (HTTP/JSON, gRPC)
+* **検証ツール**: curl, grpcurl
 
 ## 5. PoCで証明するシナリオ
 
-1. 正常系: プレミアムユーザーが200文字の投稿に成功すること。
-2. UX改善: フリーユーザーが101文字入力した瞬間に、送信ボタンが無効化されエラーコードに対応した日本語メッセージ（i18n）が出ること。
-3. ~~動的更新: `descriptor.bin` を更新（例：free制限を50文字に変更）してリリースした際、数分以内に全コンテナが再起動なしで新しいルールを適用すること。~~ **[検証結果]** protovalidateの制約により不可。スキーマ更新はリビルド・再デプロイが必要。ISRポーリング機構は実装済みだが、バリデーションルールの動的更新には使用できない。
-4. 防御: FEをバイパスして不正な `plan` でリクエストを投げても、BEのDB補完によって正しくRejectされること。
+### FE シナリオ
+
+1. ユーザー作成
+   * CreateUser リクエストを組み立て
+   * protovalidate-ts でバリデーション
+   * パスしたら user.yaml に保存
+
+2. 投稿作成
+   * CreatePost リクエストを組み立て
+   * protovalidate-ts でバリデーション
+   * パスしたら post.yaml に保存
+
+**検証内容**: FE で protovalidate を使った宣言的バリデーションが動作すること
+
+### BE シナリオ
+
+1. **正常系**: User を作成し、その plan に応じた文字数制限で Post を作成できること
+   * free ユーザー: 100文字以内の投稿が成功
+   * pro ユーザー: 200文字以内の投稿が成功
+   * enterprise ユーザー: 300文字以内の投稿が成功
+
+2. **Context Enrichment**: YAMLから取得した user.plan を使ってバリデーションが動作すること
+   * CreatePost 時に user.yaml から user 情報を取得
+   * user.plan をリクエストに注入
+   * protovalidate が CEL 式で plan に応じた制限を適用
+
+3. **curl/grpcurl 検証**: HTTP/JSON と gRPC の両方でAPIが動作すること
+
+4. **防御**: リクエストで plan を偽装しても、BE が YAML の正しい値で上書きして検証すること
+
+## 6. 起動方法
+
+各サービスは個別に起動します（docker-compose は使用しません）:
+
+```bash
+# BE サービス
+cd services/be
+go run main.go
+
+# FE サービス（実装後）
+cd services/fe
+npm run dev
+
+# ISR サービス（参考）
+cd services/isr
+go run main.go
+```
+
+## 7. PoCの成果物
+
+1. **protovalidate による宣言的バリデーション**の実装例
+2. **Context Enrichment**（永続層の値を使った動的バリデーション）の実装例
+3. FE/BE 両方での protovalidate 動作確認
+4. curl/grpcurl による API 検証手順
+5. 設計ドキュメント・実装ガイド

--- a/docs/001-DD.001.high-level-design.md
+++ b/docs/001-DD.001.high-level-design.md
@@ -58,7 +58,7 @@
 
 #### FE (TypeScript)
 
-```
+```text
 1. リクエストを組み立て (CreateUser, CreatePost)
 2. protovalidate-ts でバリデーション
 3. パスしたら YAML ファイルに保存
@@ -66,7 +66,7 @@
 
 #### BE (Go)
 
-```
+```text
 1. リクエストを受信
 2. Connect インターセプターが自動的に protovalidate でバリデーション
 3. CreatePost の場合:

--- a/docs/001-DD.001.high-level-design.md
+++ b/docs/001-DD.001.high-level-design.md
@@ -1,131 +1,187 @@
-# Design Doc 1: 全体アーキテクチャ設計 (High-Level Design) - 改訂版
+# Design Doc 1: 全体アーキテクチャ設計 (High-Level Design) - 簡略版
 
 ## 1. 背景と課題
 
-バリデーションロジックの重複、不整合、および更新時のデプロイコストを排除するため、全レイヤーで動的に同期される「契約駆動（Contract-Driven）」なシステムを構築する。
+バリデーションロジックの重複、不整合を排除するため、`.proto` ファイルを Single Source of Truth とした「契約駆動（Contract-Driven）」なバリデーションシステムを構築する。
 
 ## 2. 設計目標
 
 * **Single Source of Truth**: `.proto` ファイルを唯一の正解とする。
-* **Dynamic Schema Distribution**: サービス再起動なしで全コンポーネントのバリデーションルールを数分以内に更新する。
-* **Decoupled Registry**: GitHub のレートリミットや認証を隠蔽し、内部サービスに最適化されたスキーマ配信を行う。
+* **Context Enrichment**: 永続層（YAML）から取得した値を使った動的バリデーションを実現する。
+* **宣言的バリデーション**: `protovalidate` (CEL) による高度なバリデーションルールを記述する。
 
-## 3. システムコンポーネント
+### スコープ外とした機能
 
-1. **Schema Source (Local Development)**:
-   * スキーマのソースコード管理と、ローカルスクリプトによるバイナリビルド・アップロードを行う。
+以下の機能は、PoCの核心検証（protovalidate + Context Enrichment）に不要なため、実装しません:
 
-2. **Internal Schema Registry (ISR)**:
-   * `descriptor.bin` をDBにキャッシュする**中央ハブ**。
-   * BE に対して、一貫したスキーマ配信 API を提供する。
+* ~~Dynamic Schema Distribution~~ - 動的スキーマ配信・同期機構
+* ~~Hot Reload~~ - protovalidateの技術的制約により実現不可
+* ~~FE-BE間の実際の通信~~ - バリデーション検証には不要
+* ~~Server Streaming~~ - バリデーション検証には不要
+* ~~ISR連携~~ - スキーマ配信が不要なため
 
-3. **Backend (Go / Connect-Go)**:
-   * ISR からスキーマを取得。
-   * DB コンテキストを注入した最終バリデーションを実行する。
-   * FE 向けにスキーマをプロキシ配信する（CORS対応）。
+## 3. システムコンポーネント（簡略版）
 
-4. **Frontend (TypeScript / Connect-Web)**:
-   * BE を経由してスキーマを取得。
-   * `protovalidate-ts` による即時フィードバックを提供。
+### 3.1 Backend (Go / Connect-Go)
 
-## 4. スキーマ配布・同期のワークフロー
+* **役割**:
+  * User API, Post API の提供
+  * Context Enrichment: YAMLから user.plan を取得してバリデーション
+  * protovalidate-go による宣言的バリデーション
 
-| ステップ | 動作内容 | 担当コンポーネント |
-| --- | --- | --- |
-| **1. Build & Upload** | `.proto` をビルドし `descriptor.bin` を ISR にアップロード | ローカルスクリプト |
-| **2. Store** | バイナリを DB に保存し、バージョン管理 | **ISR** |
-| **3. Sync (Server)** | ISR の API をポーリングし、更新があればホットスワップ | BE |
-| **4. Sync (Client)** | BE のエンドポイントをポーリングし、バイナリをロード | FE |
+* **永続化**: YAML ファイル (user.yaml, post.yaml)
 
-### スキーマバージョン不一致の解決戦略
+* **検証方法**: curl (HTTP/JSON), grpcurl (gRPC)
 
-クライアント・サーバー間のスキーマバージョン不一致を防ぐため、以下の仕組みを導入する。
+### 3.2 Frontend (TypeScript)
 
-1. **レスポンスヘッダーでのバージョン通知**:
-   * すべての API レスポンスに `X-Schema-Version` ヘッダーを付与（例: `1.0.5`）。
+* **役割**:
+  * ユーザー作成・投稿画面の実装
+  * protovalidate-ts による即時バリデーション
+  * YAML ファイルへの永続化（疑似的な実装）
 
-2. **不一致検出時の同期的スキーマ取得**:
-   * FE がリクエスト送信時、メモリ上のスキーマバージョンをヘッダー `X-Client-Schema-Version` に含める。
-   * BE がリクエストヘッダーの `X-Client-Schema-Version` と自身のバージョンを比較し、自身のバージョンが古い場合：
-     1. **リクエストをブロックし**、その場で ISR から最新の Patch を fetch する（同期的）。
-     2. fetch にはタイムアウト（例: 5秒）を設定し、タイムアウトした場合はエラーを返す（`UNAVAILABLE` または `DEADLINE_EXCEEDED`）。
-     3. fetch に成功した場合、バリデーターを更新してからリクエストを処理。
-   * FE がレスポンスヘッダーの `X-Schema-Version` を確認し、自身より新しい場合は即座に BE からスキーマを再取得。
+* **通信**: BE への実際の通信は行わない
 
-3. **ポーリングベースの定期更新**:
-   * PoC では軽量化のため、WebSocket/SSE は使用せず、1分間隔のポーリングのみで運用する。
+### 3.3 ISR (参考実装)
 
-## 5. 通信・バリデーションの流れ
+* 既存実装を維持（スキーマ管理の参考実装として）
+* BE との連携は行わない
 
-### 通信プロトコル
+## 4. 通信・バリデーションの流れ
 
-* **External (FE ↔ BE)**: Connect (HTTP/1.1 JSON)
-* **Internal (BE ↔ ISR)**: Connect (gRPC Binary 推奨 / JSON も可)
+### 4.1 通信プロトコル
 
-### 二層バリデーションの戦略
+* **BE**: Connect (HTTP/1.1 JSON, gRPC Binary)
+* **検証**: curl, grpcurl
 
-1. **FE**:
-   * `current_user.user_plan` をリクエストの `user_plan` フィールドに設定。
-   * 入力内容を `protovalidate-ts` でチェック（Optimistic）。
-   * BE に直接リクエストを送信。
-2. **BE**:
-   * DB から最新の `user.plan` を再取得。
-   * リクエストの `user_plan` フィールドを DB の値で上書きし、`protovalidate-go` で最終確定（Authoritative）。
-   * PoC では認証・認可は簡易実装とする。
+### 4.2 バリデーション戦略
 
-### 追記（インフラ構成）
-
-#### **ネットワークとサービス間通信**
-
-* **Service Discovery**: すべてのコンポーネント（ISR, BE, BFF, DB）を同一の Docker Network 内で実行する。
-* **内部接続**: 各サービスはホスト側のポートを介さず、Docker のサービス名（例: `db:5432`, `isr:50051`）を使用して直接通信する。
-* **ホストポートの固定割り当て**: 全てのサービスが Docker Compose 内で完結するため、ホスト側へのポートマッピングは固定ポート（例: `5432:5432`, `50051:50051`）を使用する。
-
-### README.md への記載（開発者向けガイド）
-
-プロジェクトの `README.md` に、この動的な仕組みをどう扱うかを書いておくと親切です。
-
-> ### 🛠 開発環境のセットアップ
->
-> 本プロジェクトは Docker Compose 内で通信が完結するように設計されています。
->
-> ```bash
-> # サービスの起動
-> docker compose up -d
-> ```
->
-> **接続情報:**
->
-> * **コンテナ間**: `host: db`, `port: 5432`
-> * **ホストから**: `localhost:5432` (固定ポート)
->
-
-### 具体的な `docker-compose.yml` のイメージ
-
-この設計をコードに落とし込むと、以下のようになります。
-
-```yaml
-services:
-  db:
-    image: postgres:16-alpine
-    ports:
-      - "5432:5432" # 固定ポート
-
-  isr:
-    build: ./services/isr
-    environment:
-      - CELO_DB_URL=postgres://user:password@db:5432/isr # サービス名で指定
-      - CELO_SCHEMA_TARGET=1.0 # ターゲットとする Major.Minor バージョン
-    depends_on:
-      - db
-
-  be:
-    build: ./services/be
-    environment:
-      - CELO_DB_URL=postgres://user:password@db:5432/be
-      - CELO_ISR_URL=isr:50051 # サービス名で指定
-      - CELO_SCHEMA_TARGET=1.0 # ターゲットとする Major.Minor バージョン
-    depends_on:
-      - isr
+#### FE (TypeScript)
 
 ```
+1. リクエストを組み立て (CreateUser, CreatePost)
+2. protovalidate-ts でバリデーション
+3. パスしたら YAML ファイルに保存
+```
+
+#### BE (Go)
+
+```
+1. リクエストを受信
+2. Connect インターセプターが自動的に protovalidate でバリデーション
+3. CreatePost の場合:
+   a. user.yaml から user 情報を取得 (Context Enrichment)
+   b. user.plan に応じたバリデーションが適用される
+4. パスしたら YAML ファイルに保存
+```
+
+### 4.3 Context Enrichment の詳細
+
+**CreatePost の処理フロー**:
+
+1. クライアントから CreatePost リクエストを受信
+2. リクエストに含まれる `user_id` を使って user.yaml から User を取得
+3. 取得した `user.plan` を使ってバリデーション
+   * free: message は 100文字以内
+   * pro: message は 200文字以内
+   * enterprise: message は 300文字以内
+4. バリデーション成功後、post.yaml に保存
+
+**セキュリティ**: リクエストで plan を偽装しても、BE が YAML から取得した正しい値で検証する
+
+## 5. ディレクトリ構成
+
+```bash
+building-a-schema-first-dynamic-validation-system/
+├── proto/                    # .proto ファイル群
+├── pkg/gen/                  # 生成コード
+│   ├── go/                   # Go 用生成コード
+│   └── ts/                   # TypeScript 用生成コード
+├── services/
+│   ├── be/                   # Backend サービス
+│   │   ├── main.go
+│   │   ├── internal/
+│   │   │   ├── handler/      # API ハンドラー
+│   │   │   ├── repository/   # YAML 永続化
+│   │   │   └── validator/    # protovalidate wrapper
+│   │   └── data/             # YAML ファイル格納
+│   │       ├── user.yaml
+│   │       └── post.yaml
+│   ├── fe/                   # Frontend サービス
+│   │   └── src/
+│   │       ├── components/   # UI コンポーネント
+│   │       ├── validators/   # protovalidate-ts wrapper
+│   │       └── data/         # YAML ファイル格納
+│   └── isr/                  # ISR サービス (参考)
+├── docs/                     # 設計ドキュメント
+└── README.md
+```
+
+## 6. 起動方法
+
+各サービスは個別に起動します（docker-compose は使用しません）:
+
+```bash
+# BE サービス
+cd services/be
+go run main.go
+# -> http://localhost:50052 で起動
+
+# FE サービス（実装後）
+cd services/fe
+npm run dev
+# -> http://localhost:3000 で起動
+
+# ISR サービス（参考）
+cd services/isr
+go run main.go
+# -> http://localhost:50051 で起動
+```
+
+## 7. 検証方法
+
+### curl による検証 (HTTP/JSON)
+
+```bash
+# User 作成
+curl -X POST http://localhost:50052/user.v1.UserService/CreateUser \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "plan": "USER_PLAN_PRO"
+  }'
+
+# User 一覧
+curl http://localhost:50052/user.v1.UserService/ListUsers \
+  -H "Content-Type: application/json" \
+  -d '{"page": 1, "pageSize": 10}'
+```
+
+### grpcurl による検証 (gRPC)
+
+```bash
+# User 作成
+grpcurl -plaintext \
+  -d '{
+    "name": "John Doe",
+    "email": "john@example.com",
+    "plan": "USER_PLAN_PRO"
+  }' \
+  localhost:50052 \
+  user.v1.UserService/CreateUser
+```
+
+## 8. この設計のメリット
+
+1. **シンプル**: サービス間依存がなく、各サービスを独立して開発・検証できる
+2. **焦点を絞った検証**: protovalidate + Context Enrichment という核心機能に集中
+3. **軽量**: PostgreSQL、docker-compose などの重いインフラが不要
+4. **学習コスト低**: YAML永続化により、実装がシンプルで理解しやすい
+
+## 9. 制約事項
+
+1. **永続化**: YAML ファイルは並行書き込みに対応していない（PoCでは許容）
+2. **通信**: FE-BE間の実際の通信は行わない（各層で独立してバリデーション検証）
+3. **スキーマ配信**: 動的なスキーマ配信・同期機構は実装しない
+4. **Hot Reload**: protovalidateの制約により実現不可（詳細は [Design Doc 3 § 7.1](001-DD.003.validation-strategy.md#71-実装結果と重要な制約事項)）

--- a/docs/001-DD.001.high-level-design.md
+++ b/docs/001-DD.001.high-level-design.md
@@ -128,11 +128,13 @@ go run main.go
 # -> http://localhost:50052 で起動
 
 # FE サービス（実装後）
+# 別ターミナルで実行:
 cd services/fe
 npm run dev
 # -> http://localhost:3000 で起動
 
 # ISR サービス（参考）
+# 別ターミナルで実行:
 cd services/isr
 go run main.go
 # -> http://localhost:50051 で起動
@@ -153,7 +155,7 @@ curl -X POST http://localhost:50052/user.v1.UserService/CreateUser \
   }'
 
 # User 一覧
-curl http://localhost:50052/user.v1.UserService/ListUsers \
+curl -X POST http://localhost:50052/user.v1.UserService/ListUsers \
   -H "Content-Type: application/json" \
   -d '{"page": 1, "pageSize": 10}'
 ```

--- a/docs/001-DD.001.high-level-design.md
+++ b/docs/001-DD.001.high-level-design.md
@@ -121,8 +121,10 @@ building-a-schema-first-dynamic-validation-system/
 
 各サービスは個別に起動します（docker-compose は使用しません）:
 
+**注**: 現状の BE 実装は PostgreSQL ベースのため、YAML 永続化への移行（Task 3-3）完了後に以下の手順が有効になります。現時点では `docker-compose up -d` または `CELO_DB_URL` 環境変数の設定が必要です。
+
 ```bash
-# BE サービス
+# BE サービス（YAML 永続化移行後）
 cd services/be
 go run main.go
 # -> http://localhost:50052 で起動

--- a/docs/001-DD.004.data-model-and-api-interface.md
+++ b/docs/001-DD.004.data-model-and-api-interface.md
@@ -68,6 +68,7 @@ posts:
 | created_at | timestamp | - | 作成日時 |
 
 **message の制約** (Context Enrichment):
+
 * free: 100文字以内
 * pro: 200文字以内
 * enterprise: 300文字以内
@@ -79,6 +80,7 @@ posts:
 #### CreateUser
 
 **Request**:
+
 ```protobuf
 message CreateUserRequest {
   string name = 1 [(buf.validate.field).string = {
@@ -91,6 +93,7 @@ message CreateUserRequest {
 ```
 
 **Response**:
+
 ```protobuf
 message CreateUserResponse {
   User user = 1;
@@ -98,6 +101,7 @@ message CreateUserResponse {
 ```
 
 **処理フロー**:
+
 1. リクエストをバリデーション
 2. UUID v7 を生成
 3. user.yaml に追加
@@ -106,6 +110,7 @@ message CreateUserResponse {
 #### ListUsers
 
 **Request**:
+
 ```protobuf
 message ListUsersRequest {
   int32 page = 1 [(buf.validate.field).int32 = {gte: 1}];
@@ -117,6 +122,7 @@ message ListUsersRequest {
 ```
 
 **Response**:
+
 ```protobuf
 message ListUsersResponse {
   repeated User users = 1;
@@ -125,6 +131,7 @@ message ListUsersResponse {
 ```
 
 **処理フロー**:
+
 1. リクエストをバリデーション
 2. user.yaml から全ユーザーを読み込み
 3. ページネーション処理
@@ -135,6 +142,7 @@ message ListUsersResponse {
 #### CreatePost
 
 **Request**:
+
 ```protobuf
 message CreatePostRequest {
   string user_id = 1 [(buf.validate.field).string.uuid = true];
@@ -146,6 +154,7 @@ message CreatePostRequest {
 ```
 
 **Response**:
+
 ```protobuf
 message CreatePostResponse {
   Post post = 1;
@@ -153,6 +162,7 @@ message CreatePostResponse {
 ```
 
 **処理フロー** (Context Enrichment):
+
 1. リクエストをバリデーション（基本チェック）
 2. user.yaml から user_id に対応する User を取得
 3. user.plan に基づいて message の長さを検証
@@ -166,6 +176,7 @@ message CreatePostResponse {
 #### ListPosts
 
 **Request**:
+
 ```protobuf
 message ListPostsRequest {
   int32 page = 1 [(buf.validate.field).int32 = {gte: 1}];
@@ -177,6 +188,7 @@ message ListPostsRequest {
 ```
 
 **Response**:
+
 ```protobuf
 message ListPostsResponse {
   repeated Post posts = 1;
@@ -185,6 +197,7 @@ message ListPostsResponse {
 ```
 
 **処理フロー**:
+
 1. リクエストをバリデーション
 2. post.yaml から全投稿を読み込み
 3. ページネーション処理

--- a/docs/001-DD.004.data-model-and-api-interface.md
+++ b/docs/001-DD.004.data-model-and-api-interface.md
@@ -1,114 +1,297 @@
-# Design Doc 4: データモデル & API インターフェース (DB 分離版)
+# Design Doc 4: データモデル & API インターフェース (YAML版)
 
-## 1. データベース構成
+## 1. 永続化方式
 
-1 つの PostgreSQL コンテナ内に 2 つの独立したデータベースを作成します。
+PostgreSQL の代わりに **YAML ファイル** を使用します。
 
-* **Database:** `isr` (Internal Schema Registry 用)
-  * `schemas` テーブルを保持。
+* **保存場所**: `services/{be,fe}/data/`
+* **ファイル**:
+  * `user.yaml`: ユーザー情報
+  * `post.yaml`: 投稿情報
 
-* **Database:** `be` (Backend ビジネスロジック用)
-  * `users`, `posts` テーブルを保持。
+### 1.1 YAMLフォーマット
 
-### 1.1 `isr.schemas`
-
-```sql
-CREATE TABLE schemas (
-    id          UUID PRIMARY KEY,
-    major       INTEGER NOT NULL,
-    minor       INTEGER NOT NULL,
-    patch       INTEGER NOT NULL,
-    full_tag    TEXT NOT NULL,
-    descriptor  BYTEA NOT NULL,
-    created_at  TIMESTAMP WITH TIME ZONE NOT NULL,
-    UNIQUE(major, minor, patch)
-);
-
-```
-
-### 1.2 `be.users` & `be.posts`
-
-集約外のため、FK（外部キー制約）はあえて設けず、アプリケーションレイヤーで整合性を管理します。
-
-```sql
--- be.users
-CREATE TABLE users (
-    id         UUID PRIMARY KEY,
-    name       VARCHAR(100) NOT NULL,
-    plan       VARCHAR(20) NOT NULL CHECK (plan IN ('free', 'premium')),
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL
-);
-
--- be.posts
-CREATE TABLE posts (
-    id         UUID PRIMARY KEY,
-    user_id    UUID NOT NULL, -- FKなし
-    message    TEXT NOT NULL,
-    created_at TIMESTAMP WITH TIME ZONE NOT NULL
-);
-
-```
-
----
-
-## 2. 実装の準備: `docker-compose.yml` と初期化
-
-PostgreSQL は起動時に `/docker-entrypoint-initdb.d/` にある `.sql` または `.sh` を実行します。これを利用して、複数の DB を自動生成します。
-
-### 2.1 初期化スクリプト案 (`init.sh`)
-
-```bash
-#!/bin/bash
-set -e
-
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    CREATE DATABASE isr;
-    CREATE DATABASE be;
-EOSQL
-
-```
-
-### 2.2 `docker-compose.yml` のイメージ
+#### user.yaml
 
 ```yaml
-services:
-  db:
-    image: postgres:16-alpine
-    environment:
-      POSTGRES_USER: user
-      POSTGRES_PASSWORD: password
-    volumes:
-      - ./init-db:/docker-entrypoint-initdb.d # 上記 init.sh を配置
-    ports:
-      - "5432:5432"
+users:
+  - id: "01936d8c-5b3e-7890-abcd-123456789abc"  # UUID v7
+    name: "John Doe"
+    email: "john@example.com"
+    plan: "pro"
+    created_at: "2024-02-23T10:00:00Z"
+    updated_at: "2024-02-23T10:00:00Z"
 
+  - id: "01936d8c-5b3e-7890-abcd-987654321xyz"
+    name: "Jane Smith"
+    email: "jane@example.com"
+    plan: "free"
+    created_at: "2024-02-23T11:00:00Z"
+    updated_at: "2024-02-23T11:00:00Z"
 ```
 
----
+#### post.yaml
 
-## 3. UUID v7 の実装方針
+```yaml
+posts:
+  - id: "01936d8c-6c4f-7890-1234-abcdefabcdef"  # UUID v7
+    user_id: "01936d8c-5b3e-7890-abcd-123456789abc"
+    message: "This is a test post"
+    created_at: "2024-02-23T12:00:00Z"
+
+  - id: "01936d8c-6c4f-7890-5678-fedcbafedcba"
+    user_id: "01936d8c-5b3e-7890-abcd-987654321xyz"
+    message: "Another post"
+    created_at: "2024-02-23T13:00:00Z"
+```
+
+## 2. データモデル
+
+### 2.1 User
+
+| フィールド | 型 | 制約 | 説明 |
+|-----------|---|------|------|
+| id | UUID v7 | Primary Key | ユーザーID |
+| name | string | 1-100文字 | ユーザー名 |
+| email | string | メール形式 | メールアドレス |
+| plan | enum | free, pro, enterprise | プラン |
+| created_at | timestamp | - | 作成日時 |
+| updated_at | timestamp | - | 更新日時 |
+
+### 2.2 Post
+
+| フィールド | 型 | 制約 | 説明 |
+|-----------|---|------|------|
+| id | UUID v7 | Primary Key | 投稿ID |
+| user_id | UUID v7 | - | ユーザーID（外部キーなし） |
+| message | string | plan による可変制限 | 投稿内容 |
+| created_at | timestamp | - | 作成日時 |
+
+**message の制約** (Context Enrichment):
+* free: 100文字以内
+* pro: 200文字以内
+* enterprise: 300文字以内
+
+## 3. API インターフェース
+
+### 3.1 User API
+
+#### CreateUser
+
+**Request**:
+```protobuf
+message CreateUserRequest {
+  string name = 1 [(buf.validate.field).string = {
+    min_len: 1,
+    max_len: 100
+  }];
+  string email = 2 [(buf.validate.field).string.email = true];
+  common.v1.UserPlan plan = 3 [(buf.validate.field).enum.defined_only = true];
+}
+```
+
+**Response**:
+```protobuf
+message CreateUserResponse {
+  User user = 1;
+}
+```
+
+**処理フロー**:
+1. リクエストをバリデーション
+2. UUID v7 を生成
+3. user.yaml に追加
+4. 作成した User を返す
+
+#### ListUsers
+
+**Request**:
+```protobuf
+message ListUsersRequest {
+  int32 page = 1 [(buf.validate.field).int32 = {gte: 1}];
+  int32 page_size = 2 [(buf.validate.field).int32 = {
+    gte: 1,
+    lte: 100
+  }];
+}
+```
+
+**Response**:
+```protobuf
+message ListUsersResponse {
+  repeated User users = 1;
+  int32 total = 2;
+}
+```
+
+**処理フロー**:
+1. リクエストをバリデーション
+2. user.yaml から全ユーザーを読み込み
+3. ページネーション処理
+4. ユーザーリストを返す
+
+### 3.2 Post API
+
+#### CreatePost
+
+**Request**:
+```protobuf
+message CreatePostRequest {
+  string user_id = 1 [(buf.validate.field).string.uuid = true];
+  string message = 2 [(buf.validate.field).string = {
+    min_len: 1,
+    // max_len は Context Enrichment で動的に決定
+  }];
+}
+```
+
+**Response**:
+```protobuf
+message CreatePostResponse {
+  Post post = 1;
+}
+```
+
+**処理フロー** (Context Enrichment):
+1. リクエストをバリデーション（基本チェック）
+2. user.yaml から user_id に対応する User を取得
+3. user.plan に基づいて message の長さを検証
+   * free: 100文字以内
+   * pro: 200文字以内
+   * enterprise: 300文字以内
+4. UUID v7 を生成
+5. post.yaml に追加
+6. 作成した Post を返す
+
+#### ListPosts
+
+**Request**:
+```protobuf
+message ListPostsRequest {
+  int32 page = 1 [(buf.validate.field).int32 = {gte: 1}];
+  int32 page_size = 2 [(buf.validate.field).int32 = {
+    gte: 1,
+    lte: 100
+  }];
+}
+```
+
+**Response**:
+```protobuf
+message ListPostsResponse {
+  repeated Post posts = 1;
+  int32 total = 2;
+}
+```
+
+**処理フロー**:
+1. リクエストをバリデーション
+2. post.yaml から全投稿を読み込み
+3. ページネーション処理
+4. 投稿リストを返す
+
+## 4. UUID v7 の実装方針
 
 * **生成タイミング**:
-  * `CreateUser`, `CreatePost` のリクエスト: **FE が生成**し、リクエストに含める。
-  * `UploadSchema` のスクリプト: スクリプト実行時に生成。
+  * BE: `CreateUser`, `CreatePost` のハンドラー内で生成
+  * FE: 各画面で生成（YAMLに保存時）
 
-* **バリデーション**: BE では送られてきた UUID が正しい形式（v7 形式のチェックはライブラリで可能）であることを確認し、DB に保存。
+* **ライブラリ**:
+  * Go: `github.com/google/uuid`
+  * TypeScript: `uuid` package
 
-* **メリット**: FE で UUID を生成することで、完全な protovalidate の検証（UUID フィールドの形式チェック）を全レイヤーで証明できる。
+## 5. YAML 永続化の実装
 
----
+### 5.1 Repository インターフェース (Go)
 
-## 4. プロジェクトのディレクトリ構成 (Final)
+```go
+type UserRepository interface {
+    Create(ctx context.Context, user *model.User) error
+    List(ctx context.Context, page, pageSize int) ([]*model.User, int, error)
+    GetByID(ctx context.Context, id string) (*model.User, error)
+}
+
+type PostRepository interface {
+    Create(ctx context.Context, post *model.Post) error
+    List(ctx context.Context, page, pageSize int) ([]*model.Post, int, error)
+}
+```
+
+### 5.2 実装方針
+
+* YAML ファイルの読み込み: 起動時に全件メモリにロード
+* 書き込み: 追加時にファイルを上書き
+* 排他制御: PoCでは実装しない（単一ゴルーチン前提）
+
+### 5.3 ディレクトリ構成
 
 ```bash
-celo/
-├── init-db/             # DB初期化スクリプト
-├── proto/               # .protoファイル群
-├── scripts/             # upload_schema.sh (UUID v7生成 & ISRへPost)
-├── services/
-│   ├── isr/             # ISR (Connect to isr)
-│   ├── be/              # BE (Connect to be)
-│   └── fe/              # FE (React/TypeScript)
-└── docker-compose.yml
-
+services/be/
+├── data/
+│   ├── user.yaml
+│   └── post.yaml
+├── internal/
+│   ├── repository/
+│   │   ├── yaml_user_repository.go
+│   │   └── yaml_post_repository.go
+│   └── model/
+│       ├── user.go
+│       └── post.go
+└── main.go
 ```
+
+## 6. Context Enrichment の実装
+
+### 6.1 CreatePost ハンドラーの疑似コード
+
+```go
+func (h *PostHandler) CreatePost(
+    ctx context.Context,
+    req *connect.Request[postv1.CreatePostRequest],
+) (*connect.Response[postv1.CreatePostResponse], error) {
+    // 1. user.yaml から User を取得
+    user, err := h.userRepo.GetByID(ctx, req.Msg.UserId)
+    if err != nil {
+        return nil, connect.NewError(connect.CodeNotFound, err)
+    }
+
+    // 2. user.plan に基づいて message の長さを検証
+    maxLen := getMaxLengthForPlan(user.Plan)
+    if len(req.Msg.Message) > maxLen {
+        return nil, connect.NewError(
+            connect.CodeInvalidArgument,
+            fmt.Errorf("message too long for %s plan (max: %d)", user.Plan, maxLen),
+        )
+    }
+
+    // 3. Post を作成
+    post := &model.Post{
+        ID:        uuid.NewV7().String(),
+        UserID:    req.Msg.UserId,
+        Message:   req.Msg.Message,
+        CreatedAt: time.Now(),
+    }
+
+    // 4. post.yaml に保存
+    if err := h.postRepo.Create(ctx, post); err != nil {
+        return nil, connect.NewError(connect.CodeInternal, err)
+    }
+
+    return connect.NewResponse(&postv1.CreatePostResponse{
+        Post: toProtoPost(post),
+    }), nil
+}
+```
+
+## 7. この設計のメリット
+
+1. **シンプル**: PostgreSQL のセットアップが不要
+2. **可視性**: YAML ファイルをテキストエディタで直接確認・編集可能
+3. **軽量**: データベースドライバ、マイグレーション不要
+4. **検証容易**: ファイルを直接編集してテストデータを用意できる
+
+## 8. 制約事項
+
+1. **並行性**: 複数リクエストの同時書き込みに対応していない（PoCでは許容）
+2. **パフォーマンス**: 全件メモリロードのため、大量データには不向き（PoCでは問題なし）
+3. **整合性**: 外部キー制約がないため、アプリケーション層で管理が必要

--- a/docs/003-TASK.001.tasks.md
+++ b/docs/003-TASK.001.tasks.md
@@ -5,10 +5,9 @@
 * **Background**: 複数言語・複数サービスを円滑に管理するため、Go Workspaces と Node.js Workspaces を導入します。また、`CELO_` プレフィックスを用いた環境変数規約を確立します。
 * **Acceptance Criteria**:
   * ルートに `go.work` が存在し、各サービスを認識していること。
-  * `docker compose up -d` で Postgres が起動し、`init.sh` により `isr`, `be` が作成されること。
-  * 各サービスが `CELO_DB_URL` などの統一的な環境変数で設定可能であること。
+  * 各サービスが `CELO_DB_URL` などの統一的な環境変数で設定可能であること（PostgreSQL は使用しないが、ISR は既存実装を維持）。
 
-* **批判的視点への対策**: 接続文字列の形式を全サービスで統一（`postgres://user:pass@host:port/db`）し、環境変数の不一致による起動失敗を防止。
+* **批判的視点への対策**: 環境変数の形式を全サービスで統一し、不一致による起動失敗を防止。
 
 ## Task 1-2: Proto定義と「型専用共有モジュール」の確立
 
@@ -25,7 +24,7 @@
 ## Milestone 1 時点の想定ディレクトリ構造
 
 ```bash
-celo/
+building-a-schema-first-dynamic-validation-system/
 ├── go.work              # Go Workspaces (isr, be, pkg/gen を管理)
 ├── package.json         # Node Workspaces (fe, e2e を管理)
 ├── buf.gen.yaml         # pkg/gen/ への出力を定義
@@ -40,74 +39,137 @@ celo/
 │   ├── be/
 │   │   └── go.mod       # pkg/gen/go を参照
 │   └── fe/
-├── init-db/
-│   └── init.sh          # DB分離ロジック
-└── docker-compose.yml   # 動的ポート割り当て
-
+└── README.md
 ```
+
+**注**: docker-compose.yml は削除されました（サービス間依存がないため）
 
 ---
 
 ## Milestone 2: ISR (レジストリ) & Schema Push
 
-### Task: ISR サービスの基本実装
+### Task 2-1: ISR サービスの基本実装
 
-* **Background**: スキーマバイナリを SemVer 管理・配信するハブを作成する。
+* **Background**: スキーマバイナリを SemVer 管理・配信するハブを作成する（参考実装として維持）。
 * **Acceptance Criteria**:
-* `UploadSchema` でバイナリ保存、`GetLatestPatch` で最新版を返却できること。
+  * `UploadSchema` でバイナリ保存、`GetLatestPatch` で最新版を返却できること。
+  * PostgreSQL を使用した実装（BE との連携は行わない）。
 
-### Task: Local Upload スクリプトの実装
+### Task 2-2: Local Upload スクリプトの実装
 
 * **Background**: 開発環境から ISR へ UUID v7 を伴う最新スキーマを送り込む。
 * **Acceptance Criteria**:
-* スクリプト一発で `.proto` ビルドから ISR 登録までが完了すること。
+  * スクリプト一発で `.proto` ビルドから ISR 登録までが完了すること。
+
+**注**: ISR は参考実装として残しますが、BE との連携は行いません。
 
 ---
 
-## Milestone 3: Backend (BE) 実装 & ホットリロード
+## Milestone 3: Backend (BE) 実装
 
-### Task: BE サービスの基盤と User API
+### Task 3-1: BE サービスの基盤と User API ✅
 
 * **Background**: ユーザー情報の保存と取得を実装し、IDに UUID v7 を採用する。
 * **Acceptance Criteria**:
-* ユーザーの新規作成と一覧取得ができること。
+  * ユーザーの新規作成と一覧取得ができること。
+  * PostgreSQL を使用した実装が完了していること。
 
-### Task: 動的スキーマ同期 (Hot Reload) 実装 ❌ 制約により不可
+**Status**: 完了（PostgreSQL版）
+
+### Task 3-2: 動的スキーマ同期 (Hot Reload) 実装 ❌ 制約により不可
 
 * **Background**: 1分周期のポーリングと、バリデーターの Atomic Swap を実装する。
-* **Acceptance Criteria**:
-* ~~アプリを止めずに、ログ上でスキーマバージョンの更新が確認できること。~~
 * **実装結果**: ISRポーリング機構とスキーマ取得は実装完了。ログ出力も正常に動作。しかし、protovalidateが静的メッセージの`msg.ProtoReflect().Descriptor()`を参照するため、**バリデーションルールの動的更新は不可能**と判明。詳細は[Design Doc 3 § 7.1](001-DD.003.validation-strategy.md#71-実装結果と重要な制約事項)参照。
 
-### Task: Post API と Context Enrichment 実装
+**Status**: 技術的制約により中止
 
-* **Background**: `_plan` 注入と `protovalidate` による検証を実装。
+### Task 3-3: BE の YAML 永続化実装
+
+* **Background**: PostgreSQL を YAML ファイルに置き換え、シンプルな永続化を実現する。
 * **Acceptance Criteria**:
-* **Testcontainers-go** による統合テストがパスすること。
-* バリデーションエラーに `Design Doc 5` 仕様の `message_id` 等が含まれること。
+  * User API (CreateUser, ListUsers) が YAML ファイルで動作すること。
+  * `services/be/data/user.yaml` にデータが保存されること。
+  * 既存の Repository インターフェースを維持すること。
+
+**実装内容**:
+  * `YAMLUserRepository` の実装
+  * user.yaml のフォーマット定義
+  * 起動時の YAML ロード処理
+
+### Task 3-4: Post API と Context Enrichment 実装
+
+* **Background**: Post API を実装し、Context Enrichment（user.plan を使った動的バリデーション）を実現する。
+* **Acceptance Criteria**:
+  * CreatePost, ListPosts が実装されていること。
+  * CreatePost 時に user.yaml から user.plan を取得し、plan に応じた message 長制限を適用すること。
+  * free: 100文字、pro: 200文字、enterprise: 300文字
+  * `services/be/data/post.yaml` にデータが保存されること。
+  * curl/grpcurl でテストできること。
+
+**実装内容**:
+  * `PostHandler` の実装
+  * `YAMLPostRepository` の実装
+  * Context Enrichment ロジック
+  * post.yaml のフォーマット定義
 
 ---
 
-## Milestone 4: Frontend & E2E
+## Milestone 4: Frontend 実装
 
-### Task: Backend (Go) にスキーマ配信エンドポイントを追加
+### Task 4-1: FE の簡易実装
 
-* **Background**: FE 向けのスキーマ配信エンドポイントを BE に実装（ISR へのプロキシ）。
+* **Background**: protovalidate-ts を使ったクライアント側バリデーションを実装する。実際の BE 通信は行わず、YAML 永続化による疑似的な実装を行う。
 * **Acceptance Criteria**:
-* `/api/v1/schema/latest` エンドポイントが実装され、CORS設定が完了していること。
-* レスポンスヘッダーに `X-Schema-Version` を付与すること。
+  * ユーザー作成画面が実装されていること。
+  * 投稿作成・一覧画面が実装されていること。
+  * protovalidate-ts によるバリデーションが動作すること。
+  * `services/fe/data/user.yaml`, `services/fe/data/post.yaml` にデータが保存されること。
+  * BE への実際の通信は行わないこと。
 
-### Task: Frontend (React) と動的バリデーション UI
+**実装内容**:
+  * React/Vue/Svelte のいずれかで実装
+  * protovalidate-ts の組み込み
+  * YAML 読み書き処理
+  * 基本的な UI コンポーネント
 
-* **Background**: 即時フィードバックとバックグラウンドでのスキーマ更新を実装。
+**スコープ外**:
+  * ~~BE との実際の通信~~
+  * ~~スキーマの定期取得~~
+  * ~~Server Streaming~~
+  * ~~E2Eテスト~~
+
+---
+
+## Milestone 5: ドキュメント整備
+
+### Task 5-1: 検証手順書の作成
+
+* **Background**: curl/grpcurl を使った検証手順を整備する。
 * **Acceptance Criteria**:
-* protovalidate-ts を使用した即時バリデーションが機能すること。
-* スキーマ更新後、リロードなしで入力エラーの閾値が変化すること。
-* BE に直接リクエストを送信できること。
+  * User API の検証手順が記載されていること。
+  * Post API の検証手順が記載されていること（Context Enrichment の検証を含む）。
+  * セキュリティ検証（plan 偽装）の手順が記載されていること。
 
-### Task: シナリオテスト (Playwright) の導入
+### Task 5-2: README の更新
 
-* **Background**: YAML シナリオに基づく全系の自動検証を Testcontainers 上で行う。
+* **Background**: PoC のスコープ変更を反映し、起動方法を明記する。
 * **Acceptance Criteria**:
-* 全シナリオ（正常・異常・偽装リクエスト）が CI 上で完走すること。
-* FE/BE 構成でのE2Eテストが正常に動作すること。
+  * docker-compose.yml が不要になったことが記載されていること。
+  * 各サービスの個別起動方法が記載されていること。
+  * YAML 永続化の仕組みが説明されていること。
+  * PoC の目的（protovalidate + Context Enrichment の検証）が明記されていること。
+
+---
+
+## タスクの優先順位
+
+| Priority | Task | Milestone |
+|----------|------|-----------|
+| 高 | Task 3-3: BE の YAML 永続化実装 | M3 |
+| 高 | Task 3-4: Post API と Context Enrichment 実装 | M3 |
+| 中 | Task 4-1: FE の簡易実装 | M4 |
+| 中 | Task 5-1: 検証手順書の作成 | M5 |
+| 中 | Task 5-2: README の更新 | M5 |
+| 低 | Task 2-1, 2-2: ISR 関連 | M2 |
+
+**注**: Milestone 1 は完了済み、Milestone 2 の ISR は参考実装として残すが優先度は低い。

--- a/docs/003-TASK.001.tasks.md
+++ b/docs/003-TASK.001.tasks.md
@@ -92,9 +92,10 @@ building-a-schema-first-dynamic-validation-system/
   * 既存の Repository インターフェースを維持すること。
 
 **実装内容**:
-  * `YAMLUserRepository` の実装
-  * user.yaml のフォーマット定義
-  * 起動時の YAML ロード処理
+
+* `YAMLUserRepository` の実装
+* user.yaml のフォーマット定義
+* 起動時の YAML ロード処理
 
 ### Task 3-4: Post API と Context Enrichment 実装
 
@@ -107,10 +108,11 @@ building-a-schema-first-dynamic-validation-system/
   * curl/grpcurl でテストできること。
 
 **実装内容**:
-  * `PostHandler` の実装
-  * `YAMLPostRepository` の実装
-  * Context Enrichment ロジック
-  * post.yaml のフォーマット定義
+
+* `PostHandler` の実装
+* `YAMLPostRepository` の実装
+* Context Enrichment ロジック
+* post.yaml のフォーマット定義
 
 ---
 
@@ -127,16 +129,18 @@ building-a-schema-first-dynamic-validation-system/
   * BE への実際の通信は行わないこと。
 
 **実装内容**:
-  * React/Vue/Svelte のいずれかで実装
-  * protovalidate-ts の組み込み
-  * YAML 読み書き処理
-  * 基本的な UI コンポーネント
+
+* React/Vue/Svelte のいずれかで実装
+* protovalidate-ts の組み込み
+* YAML 読み書き処理
+* 基本的な UI コンポーネント
 
 **スコープ外**:
-  * ~~BE との実際の通信~~
-  * ~~スキーマの定期取得~~
-  * ~~Server Streaming~~
-  * ~~E2Eテスト~~
+
+* ~~BE との実際の通信~~
+* ~~スキーマの定期取得~~
+* ~~Server Streaming~~
+* ~~E2Eテスト~~
 
 ---
 

--- a/docs/003-TASK.001.tasks.md
+++ b/docs/003-TASK.001.tasks.md
@@ -42,7 +42,7 @@ building-a-schema-first-dynamic-validation-system/
 └── README.md
 ```
 
-**注**: docker-compose.yml は削除されました（サービス間依存がないため）
+**注**: docker-compose.yml は今後削除予定です（サービス間依存がないため）
 
 ---
 
@@ -72,9 +72,8 @@ building-a-schema-first-dynamic-validation-system/
 * **Background**: ユーザー情報の保存と取得を実装し、IDに UUID v7 を採用する。
 * **Acceptance Criteria**:
   * ユーザーの新規作成と一覧取得ができること。
-  * PostgreSQL を使用した実装が完了していること。
 
-**Status**: 完了（PostgreSQL版）
+**Status**: 完了（PostgreSQL版として実装済み。Task 3-3 で YAML に移行予定）
 
 ### Task 3-2: 動的スキーマ同期 (Hot Reload) 実装 ❌ 制約により不可
 


### PR DESCRIPTION
## 概要

PoCのスコープを絞り、**protovalidate + Context Enrichment** という核心機能に集中するためのドキュメント更新です。

## 変更内容

### 維持される核心機能
- ✅ protovalidate による宣言的バリデーション
- ✅ Context Enrichment (YAML永続層の値を使った動的バリデーション)
- ✅ FE/BE両方でのprotovalidate動作確認
- ✅ curl/grpcurlによるAPI検証

### 削除される機能
- ❌ Hot Reload (技術的制約により実現不可)
- ❌ 動的スキーマ配信・同期機構
- ❌ FE-BE間の実際の通信
- ❌ Server Streaming
- ❌ E2Eテスト (Playwright)
- ❌ PostgreSQL → **YAML永続化**に変更
- ❌ docker-compose.yml → **個別起動**に変更

## 更新されたドキュメント

- `docs/000.requirement.md`: PoCの目的を明確化、スコープ外機能を明記
- `docs/001-DD.001.high-level-design.md`: 簡略化されたアーキテクチャ
- `docs/001-DD.004.data-model-and-api-interface.md`: PostgreSQL→YAMLフォーマット定義
- `docs/003-TASK.001.tasks.md`: 新しいタスクリスト (YAML永続化、Post API)
- `README.md`: 個別起動方法、YAML永続化の説明

## スコープ変更の理由

1. **焦点を絞る**: PoCの本質的価値 (protovalidate + Context Enrichment) に集中
2. **開発期間短縮**: 付帯機能を削除し、核心機能の検証に注力
3. **シンプル化**: PostgreSQL、docker-compose等の重いインフラを削除

## 次のステップ

このPRマージ後:
1. Phase 2: インフラ削除 (docker-compose.yml, init-db/)
2. Phase 3: GitHub Issues 整理 (不要なIssueのクローズ)
3. Phase 4: 新規Issue作成 (YAML永続化実装タスク)

詳細は `__private/2026-02-23.update-plan.md` を参照してください。

## Related Issues

- Closes #17 (Hot Reload - 技術的制約により不可)
- Updates #18 (Post API - PostgreSQL→YAML)
- Updates #15 (Milestone 3 - Hot Reload削除)

🤖 Generated with [Claude Code](https://claude.com/claude-code)