### PR TITLE
Task 3-4: Implement Post API with Context Enrichment

### DIFF
--- a/services/be/internal/handler/post_handler.go
+++ b/services/be/internal/handler/post_handler.go
@@ -1,0 +1,153 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	"connectrpc.com/connect"
+	"github.com/google/uuid"
+	postv1 "github.com/poi2/building-a-schema-first-dynamic-validation-system/pkg/gen/go/post/v1"
+	"github.com/poi2/building-a-schema-first-dynamic-validation-system/services/be/internal/model"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// PostRepository interface for post data operations
+type PostRepository interface {
+	Create(ctx context.Context, post *model.Post) error
+	List(ctx context.Context, userID string, page, pageSize int) ([]*model.Post, int, error)
+	GetByID(ctx context.Context, id string) (*model.Post, error)
+}
+
+// PostHandler implements the PostService
+type PostHandler struct {
+	postRepo PostRepository
+	userRepo UserRepository
+}
+
+// NewPostHandler creates a new PostHandler
+func NewPostHandler(postRepo PostRepository, userRepo UserRepository) *PostHandler {
+	return &PostHandler{
+		postRepo: postRepo,
+		userRepo: userRepo,
+	}
+}
+
+// CreatePost creates a new post with Context Enrichment
+func (h *PostHandler) CreatePost(
+	ctx context.Context,
+	req *connect.Request[postv1.CreatePostRequest],
+) (*connect.Response[postv1.CreatePostResponse], error) {
+	// Context Enrichment: Get user's plan from user repository
+	user, err := h.userRepo.GetByID(ctx, req.Msg.UserId)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, connect.NewError(connect.CodeNotFound, err)
+		}
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	// Inject user plan into request for validation
+	req.Msg.XUserPlan = stringToUserPlan(user.Plan)
+
+	// Manual validation: Check content length based on user plan
+	// Since interceptors run before the handler, we need to validate here
+	maxContentLength := getMaxContentLengthForPlan(user.Plan)
+	contentLength := len(req.Msg.Content)
+	if contentLength > maxContentLength {
+		return nil, connect.NewError(
+			connect.CodeInvalidArgument,
+			errors.New("content exceeds plan limit (FREE: 1000, PRO: 5000, ENTERPRISE: 10000 chars)"),
+		)
+	}
+
+	// Generate UUID v7
+	id, err := uuid.NewV7()
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+	postID := id.String()
+
+	// Get current time
+	now := time.Now()
+
+	// Create post model
+	post := &model.Post{
+		ID:        postID,
+		UserID:    req.Msg.UserId,
+		Title:     req.Msg.Title,
+		Content:   req.Msg.Content,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	// Save to repository
+	if err := h.postRepo.Create(ctx, post); err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	// Convert to proto response
+	protoPost := &postv1.Post{
+		Id:        post.ID,
+		UserId:    post.UserID,
+		Title:     post.Title,
+		Content:   post.Content,
+		CreatedAt: timestamppb.New(post.CreatedAt),
+		UpdatedAt: timestamppb.New(post.UpdatedAt),
+		XUserPlan: stringToUserPlan(user.Plan),
+	}
+
+	return connect.NewResponse(&postv1.CreatePostResponse{
+		Post: protoPost,
+	}), nil
+}
+
+// ListPosts lists posts for a specific user with pagination
+func (h *PostHandler) ListPosts(
+	ctx context.Context,
+	req *connect.Request[postv1.ListPostsRequest],
+) (*connect.Response[postv1.ListPostsResponse], error) {
+	// Get pagination parameters (validated by interceptor/proto)
+	userID := req.Msg.UserId
+	page := req.Msg.Page
+	pageSize := req.Msg.PageSize
+
+	// Fetch posts from repository
+	posts, total, err := h.postRepo.List(ctx, userID, int(page), int(pageSize))
+	if err != nil {
+		return nil, connect.NewError(connect.CodeInternal, err)
+	}
+
+	// Convert to proto posts
+	protoPosts := make([]*postv1.Post, 0, len(posts))
+	for _, post := range posts {
+		protoPosts = append(protoPosts, &postv1.Post{
+			Id:        post.ID,
+			UserId:    post.UserID,
+			Title:     post.Title,
+			Content:   post.Content,
+			CreatedAt: timestamppb.New(post.CreatedAt),
+			UpdatedAt: timestamppb.New(post.UpdatedAt),
+		})
+	}
+
+	return connect.NewResponse(&postv1.ListPostsResponse{
+		Posts: protoPosts,
+		Total: int32(total),
+	}), nil
+}
+
+// getMaxContentLengthForPlan returns the maximum content length based on user plan
+func getMaxContentLengthForPlan(plan string) int {
+	switch plan {
+	case "free":
+		return 1000
+	case "pro":
+		return 5000
+	case "enterprise":
+		return 10000
+	default:
+		return 10000 // default to enterprise limit
+	}
+}

--- a/services/be/internal/handler/post_handler.go
+++ b/services/be/internal/handler/post_handler.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"time"
+	"unicode/utf8"
 
 	"connectrpc.com/connect"
 	"github.com/google/uuid"
@@ -54,7 +55,8 @@ func (h *PostHandler) CreatePost(
 	// Manual validation: Check content length based on user plan
 	// Since interceptors run before the handler, we need to validate here
 	maxContentLength := getMaxContentLengthForPlan(user.Plan)
-	contentLength := len(req.Msg.Content)
+	// Use rune count (character count) instead of byte count for proper multi-byte character handling
+	contentLength := utf8.RuneCountInString(req.Msg.Content)
 	if contentLength > maxContentLength {
 		return nil, connect.NewError(
 			connect.CodeInvalidArgument,

--- a/services/be/internal/handler/post_handler_test.go
+++ b/services/be/internal/handler/post_handler_test.go
@@ -1,0 +1,287 @@
+package handler
+
+import (
+	"context"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"connectrpc.com/connect"
+	commonv1 "github.com/poi2/building-a-schema-first-dynamic-validation-system/pkg/gen/go/common/v1"
+	postv1 "github.com/poi2/building-a-schema-first-dynamic-validation-system/pkg/gen/go/post/v1"
+	"github.com/poi2/building-a-schema-first-dynamic-validation-system/services/be/internal/model"
+)
+
+// Mock post repository for testing
+type mockPostRepository struct {
+	posts map[string]*model.Post
+}
+
+func newMockPostRepository() *mockPostRepository {
+	return &mockPostRepository{
+		posts: make(map[string]*model.Post),
+	}
+}
+
+func (m *mockPostRepository) Create(ctx context.Context, post *model.Post) error {
+	m.posts[post.ID] = post
+	return nil
+}
+
+func (m *mockPostRepository) List(ctx context.Context, userID string, page, pageSize int) ([]*model.Post, int, error) {
+	var userPosts []*model.Post
+	for _, post := range m.posts {
+		if post.UserID == userID {
+			userPosts = append(userPosts, post)
+		}
+	}
+
+	total := len(userPosts)
+	start := (page - 1) * pageSize
+	end := start + pageSize
+
+	if start >= total {
+		return []*model.Post{}, total, nil
+	}
+	if end > total {
+		end = total
+	}
+
+	return userPosts[start:end], total, nil
+}
+
+func (m *mockPostRepository) GetByID(ctx context.Context, id string) (*model.Post, error) {
+	post, ok := m.posts[id]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return post, nil
+}
+
+// Mock user repository that returns users with different plans
+type mockUserRepositoryForPost struct {
+	users map[string]*model.User
+}
+
+func newMockUserRepositoryForPost() *mockUserRepositoryForPost {
+	return &mockUserRepositoryForPost{
+		users: make(map[string]*model.User),
+	}
+}
+
+func (m *mockUserRepositoryForPost) Create(ctx context.Context, user *model.User) error {
+	m.users[user.ID] = user
+	return nil
+}
+
+func (m *mockUserRepositoryForPost) List(ctx context.Context, page, pageSize int) ([]*model.User, int, error) {
+	return nil, 0, nil
+}
+
+func (m *mockUserRepositoryForPost) GetByID(ctx context.Context, id string) (*model.User, error) {
+	user, ok := m.users[id]
+	if !ok {
+		return nil, os.ErrNotExist
+	}
+	return user, nil
+}
+
+func TestPostHandler_CreatePost_PlanBasedContentLimit(t *testing.T) {
+	postRepo := newMockPostRepository()
+	userRepo := newMockUserRepositoryForPost()
+	handler := NewPostHandler(postRepo, userRepo)
+	ctx := context.Background()
+
+	tests := []struct {
+		name          string
+		userPlan      string
+		contentLength int
+		shouldFail    bool
+	}{
+		{"FREE plan - within limit", "free", 500, false},
+		{"FREE plan - at limit", "free", 1000, false},
+		{"FREE plan - exceeds limit", "free", 1001, true},
+		{"PRO plan - within limit", "pro", 3000, false},
+		{"PRO plan - at limit", "pro", 5000, false},
+		{"PRO plan - exceeds limit", "pro", 5001, true},
+		{"ENTERPRISE plan - within limit", "enterprise", 8000, false},
+		{"ENTERPRISE plan - at limit", "enterprise", 10000, false},
+		{"ENTERPRISE plan - exceeds limit", "enterprise", 10001, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a test user with the specified plan
+			userID := "test-user-" + tt.userPlan
+			userRepo.users[userID] = &model.User{
+				ID:   userID,
+				Name: "Test User",
+				Plan: tt.userPlan,
+			}
+
+			// Create content with specified length (using multi-byte characters to test rune counting)
+			content := strings.Repeat("あ", tt.contentLength) // Japanese character (3 bytes per character)
+
+			req := connect.NewRequest(&postv1.CreatePostRequest{
+				UserId:  userID,
+				Title:   "Test Post",
+				Content: content,
+			})
+
+			resp, err := handler.CreatePost(ctx, req)
+
+			if tt.shouldFail {
+				if err == nil {
+					t.Errorf("Expected error for content length %d with plan %s, but got none", tt.contentLength, tt.userPlan)
+				}
+				if err != nil && connect.CodeOf(err) != connect.CodeInvalidArgument {
+					t.Errorf("Expected CodeInvalidArgument, got %v", connect.CodeOf(err))
+				}
+			} else {
+				if err != nil {
+					t.Errorf("Unexpected error for content length %d with plan %s: %v", tt.contentLength, tt.userPlan, err)
+				}
+				if resp != nil && resp.Msg.Post.XUserPlan == commonv1.UserPlan_USER_PLAN_UNSPECIFIED {
+					t.Error("Expected XUserPlan to be set in response")
+				}
+			}
+		})
+	}
+}
+
+func TestPostHandler_CreatePost_UserNotFound(t *testing.T) {
+	postRepo := newMockPostRepository()
+	userRepo := newMockUserRepositoryForPost()
+	handler := NewPostHandler(postRepo, userRepo)
+	ctx := context.Background()
+
+	req := connect.NewRequest(&postv1.CreatePostRequest{
+		UserId:  "non-existent-user",
+		Title:   "Test Post",
+		Content: "Test Content",
+	})
+
+	_, err := handler.CreatePost(ctx, req)
+
+	if err == nil {
+		t.Fatal("Expected error when user not found")
+	}
+
+	if connect.CodeOf(err) != connect.CodeNotFound {
+		t.Errorf("Expected CodeNotFound, got %v", connect.CodeOf(err))
+	}
+}
+
+func TestPostHandler_ListPosts_Pagination(t *testing.T) {
+	postRepo := newMockPostRepository()
+	userRepo := newMockUserRepositoryForPost()
+	handler := NewPostHandler(postRepo, userRepo)
+	ctx := context.Background()
+
+	// Create test user
+	userID := "test-user"
+	userRepo.users[userID] = &model.User{
+		ID:   userID,
+		Name: "Test User",
+		Plan: "free",
+	}
+
+	// Create some test posts
+	for i := 0; i < 5; i++ {
+		postRepo.posts["post-"+string(rune('0'+i))] = &model.Post{
+			ID:      "post-" + string(rune('0'+i)),
+			UserID:  userID,
+			Title:   "Test Post",
+			Content: "Content",
+		}
+	}
+
+	req := connect.NewRequest(&postv1.ListPostsRequest{
+		UserId:   userID,
+		Page:     1,
+		PageSize: 3,
+	})
+
+	resp, err := handler.ListPosts(ctx, req)
+	if err != nil {
+		t.Fatalf("ListPosts failed: %v", err)
+	}
+
+	if resp.Msg.Total != 5 {
+		t.Errorf("Expected total 5, got %d", resp.Msg.Total)
+	}
+
+	if len(resp.Msg.Posts) != 3 {
+		t.Errorf("Expected 3 posts in page, got %d", len(resp.Msg.Posts))
+	}
+}
+
+func TestGetMaxContentLengthForPlan(t *testing.T) {
+	tests := []struct {
+		plan     string
+		expected int
+	}{
+		{"free", 1000},
+		{"pro", 5000},
+		{"enterprise", 10000},
+		{"unknown", 10000}, // default to enterprise
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.plan, func(t *testing.T) {
+			result := getMaxContentLengthForPlan(tt.plan)
+			if result != tt.expected {
+				t.Errorf("getMaxContentLengthForPlan(%s) = %d, want %d", tt.plan, result, tt.expected)
+			}
+		})
+	}
+}
+
+// Test to verify repository error handling
+func TestPostHandler_CreatePost_RepositoryError(t *testing.T) {
+	// Create a failing post repository
+	failingRepo := &failingPostRepository{}
+	userRepo := newMockUserRepositoryForPost()
+	handler := NewPostHandler(failingRepo, userRepo)
+	ctx := context.Background()
+
+	// Create test user
+	userID := "test-user"
+	userRepo.users[userID] = &model.User{
+		ID:   userID,
+		Name: "Test User",
+		Plan: "free",
+	}
+
+	req := connect.NewRequest(&postv1.CreatePostRequest{
+		UserId:  userID,
+		Title:   "Test Post",
+		Content: "Content",
+	})
+
+	_, err := handler.CreatePost(ctx, req)
+
+	if err == nil {
+		t.Fatal("Expected error from repository")
+	}
+
+	if connect.CodeOf(err) != connect.CodeInternal {
+		t.Errorf("Expected CodeInternal, got %v", connect.CodeOf(err))
+	}
+}
+
+// Failing repository for error testing
+type failingPostRepository struct{}
+
+func (f *failingPostRepository) Create(ctx context.Context, post *model.Post) error {
+	return errors.New("repository error")
+}
+
+func (f *failingPostRepository) List(ctx context.Context, userID string, page, pageSize int) ([]*model.Post, int, error) {
+	return nil, 0, errors.New("repository error")
+}
+
+func (f *failingPostRepository) GetByID(ctx context.Context, id string) (*model.Post, error) {
+	return nil, errors.New("repository error")
+}

--- a/services/be/internal/model/post.go
+++ b/services/be/internal/model/post.go
@@ -1,0 +1,13 @@
+package model
+
+import "time"
+
+// Post represents a post in the system
+type Post struct {
+	ID        string    `yaml:"id"`
+	UserID    string    `yaml:"user_id"`
+	Title     string    `yaml:"title"`
+	Content   string    `yaml:"content"`
+	CreatedAt time.Time `yaml:"created_at"`
+	UpdatedAt time.Time `yaml:"updated_at"`
+}

--- a/services/be/internal/repository/yaml_post_repository.go
+++ b/services/be/internal/repository/yaml_post_repository.go
@@ -148,6 +148,11 @@ func (r *YAMLPostRepository) List(ctx context.Context, userID string, page, page
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
+	// Defensive validation to prevent panic from invalid inputs
+	if page < 1 || pageSize < 1 {
+		return []*model.Post{}, 0, nil
+	}
+
 	data, err := r.readFile()
 	if err != nil {
 		return nil, 0, err

--- a/services/be/internal/repository/yaml_post_repository.go
+++ b/services/be/internal/repository/yaml_post_repository.go
@@ -1,0 +1,209 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/poi2/building-a-schema-first-dynamic-validation-system/services/be/internal/model"
+	"gopkg.in/yaml.v3"
+)
+
+// YAMLPostRepository handles post data persistence using YAML files
+type YAMLPostRepository struct {
+	filePath string
+	mu       sync.RWMutex
+}
+
+// postYAMLData represents the structure of the YAML file
+type postYAMLData struct {
+	Posts []*model.Post `yaml:"posts"`
+}
+
+// NewYAMLPostRepository creates a new YAMLPostRepository
+func NewYAMLPostRepository(filePath string) (*YAMLPostRepository, error) {
+	repo := &YAMLPostRepository{
+		filePath: filePath,
+	}
+
+	// Initialize file if it doesn't exist
+	if err := repo.initFile(); err != nil {
+		return nil, fmt.Errorf("failed to initialize YAML file: %w", err)
+	}
+
+	return repo, nil
+}
+
+// initFile creates the YAML file with an empty posts array if it doesn't exist
+func (r *YAMLPostRepository) initFile() error {
+	// Check if file exists
+	if _, err := os.Stat(r.filePath); err != nil {
+		if os.IsNotExist(err) {
+			// Create directory if needed
+			dir := filepath.Dir(r.filePath)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				return fmt.Errorf("failed to create directory: %w", err)
+			}
+
+			// Create empty YAML file
+			data := postYAMLData{Posts: []*model.Post{}}
+			if err := r.writeFile(&data); err != nil {
+				return fmt.Errorf("failed to create initial file: %w", err)
+			}
+
+			return nil
+		}
+
+		return fmt.Errorf("failed to stat file: %w", err)
+	}
+
+	return nil
+}
+
+// readFile reads and parses the YAML file
+func (r *YAMLPostRepository) readFile() (*postYAMLData, error) {
+	file, err := os.ReadFile(r.filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read file: %w", err)
+	}
+
+	var data postYAMLData
+	if err := yaml.Unmarshal(file, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal YAML: %w", err)
+	}
+
+	// Initialize posts slice if nil
+	if data.Posts == nil {
+		data.Posts = []*model.Post{}
+	}
+
+	return &data, nil
+}
+
+// writeFile writes the data to the YAML file atomically
+func (r *YAMLPostRepository) writeFile(data *postYAMLData) error {
+	yamlBytes, err := yaml.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal YAML: %w", err)
+	}
+
+	// Atomic write: write to a temp file in the same directory, then rename.
+	dir := filepath.Dir(r.filePath)
+	tmpFile, err := os.CreateTemp(dir, ".tmp-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temp file: %w", err)
+	}
+	// Ensure the temp file is removed if something goes wrong before rename.
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.Write(yamlBytes); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to write temp file: %w", err)
+	}
+
+	if err := tmpFile.Sync(); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("failed to sync temp file: %w", err)
+	}
+
+	if err := tmpFile.Close(); err != nil {
+		return fmt.Errorf("failed to close temp file: %w", err)
+	}
+
+	if err := os.Rename(tmpFile.Name(), r.filePath); err != nil {
+		return fmt.Errorf("failed to replace YAML file: %w", err)
+	}
+
+	// Ensure file permissions are consistent with previous behavior.
+	if err := os.Chmod(r.filePath, 0644); err != nil {
+		return fmt.Errorf("failed to set file permissions: %w", err)
+	}
+
+	return nil
+}
+
+// Create inserts a new post into the YAML file
+func (r *YAMLPostRepository) Create(ctx context.Context, post *model.Post) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	data, err := r.readFile()
+	if err != nil {
+		return err
+	}
+
+	data.Posts = append(data.Posts, post)
+
+	if err := r.writeFile(data); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// List retrieves posts for a specific user with pagination
+func (r *YAMLPostRepository) List(ctx context.Context, userID string, page, pageSize int) ([]*model.Post, int, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	data, err := r.readFile()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	// Filter posts by user_id
+	userPosts := make([]*model.Post, 0)
+	for _, post := range data.Posts {
+		if post.UserID == userID {
+			userPosts = append(userPosts, post)
+		}
+	}
+
+	total := len(userPosts)
+
+	// Calculate pagination
+	offset := (page - 1) * pageSize
+	if offset >= total {
+		return []*model.Post{}, total, nil
+	}
+
+	end := offset + pageSize
+	if end > total {
+		end = total
+	}
+
+	// For proper DESC order, we iterate from the end and collect only the requested window
+	resultSize := end - offset
+	pagePosts := make([]*model.Post, 0, resultSize)
+
+	// In the reversed view, index 0 corresponds to userPosts[total-1],
+	// index 1 to userPosts[total-2], etc.
+	start := total - 1 - offset    // first index in userPosts for this page
+	stop := total - end            // inclusive lower bound index in userPosts
+	for i := start; i >= stop; i-- { // walk backwards to maintain newest-first order
+		pagePosts = append(pagePosts, userPosts[i])
+	}
+
+	return pagePosts, total, nil
+}
+
+// GetByID retrieves a post by ID
+func (r *YAMLPostRepository) GetByID(ctx context.Context, id string) (*model.Post, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	data, err := r.readFile()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, post := range data.Posts {
+		if post.ID == id {
+			return post, nil
+		}
+	}
+
+	return nil, fmt.Errorf("post %s: %w", id, os.ErrNotExist)
+}

--- a/services/be/internal/repository/yaml_post_repository_test.go
+++ b/services/be/internal/repository/yaml_post_repository_test.go
@@ -1,0 +1,182 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/poi2/building-a-schema-first-dynamic-validation-system/services/be/internal/model"
+)
+
+func TestYAMLPostRepository_Create(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "test_posts.yaml")
+
+	repo, err := NewYAMLPostRepository(yamlPath)
+	if err != nil {
+		t.Fatalf("Failed to create repository: %v", err)
+	}
+
+	ctx := context.Background()
+	post := &model.Post{
+		ID:        "test-post-123",
+		UserID:    "user-123",
+		Title:     "Test Post",
+		Content:   "This is a test post content",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	// Create post
+	if err := repo.Create(ctx, post); err != nil {
+		t.Fatalf("Failed to create post: %v", err)
+	}
+
+	// Verify the file exists
+	if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
+		t.Fatalf("YAML file was not created")
+	}
+
+	// Retrieve the post
+	retrieved, err := repo.GetByID(ctx, post.ID)
+	if err != nil {
+		t.Fatalf("Failed to retrieve post: %v", err)
+	}
+
+	if retrieved.ID != post.ID || retrieved.UserID != post.UserID || retrieved.Title != post.Title {
+		t.Errorf("Retrieved post does not match: got %+v, want %+v", retrieved, post)
+	}
+}
+
+func TestYAMLPostRepository_List(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "test_posts.yaml")
+
+	repo, err := NewYAMLPostRepository(yamlPath)
+	if err != nil {
+		t.Fatalf("Failed to create repository: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Create posts for multiple users
+	posts := []*model.Post{
+		{ID: "post-1", UserID: "user-1", Title: "Post 1", Content: "Content 1", CreatedAt: time.Now(), UpdatedAt: time.Now()},
+		{ID: "post-2", UserID: "user-2", Title: "Post 2", Content: "Content 2", CreatedAt: time.Now().Add(1 * time.Second), UpdatedAt: time.Now()},
+		{ID: "post-3", UserID: "user-1", Title: "Post 3", Content: "Content 3", CreatedAt: time.Now().Add(2 * time.Second), UpdatedAt: time.Now()},
+		{ID: "post-4", UserID: "user-1", Title: "Post 4", Content: "Content 4", CreatedAt: time.Now().Add(3 * time.Second), UpdatedAt: time.Now()},
+	}
+
+	for _, post := range posts {
+		if err := repo.Create(ctx, post); err != nil {
+			t.Fatalf("Failed to create post: %v", err)
+		}
+	}
+
+	// Test pagination for user-1 (has 3 posts)
+	page1, total, err := repo.List(ctx, "user-1", 1, 2)
+	if err != nil {
+		t.Fatalf("Failed to list posts: %v", err)
+	}
+
+	if total != 3 {
+		t.Errorf("Expected total 3 for user-1, got %d", total)
+	}
+
+	if len(page1) != 2 {
+		t.Fatalf("Expected 2 posts on page 1, got %d", len(page1))
+	}
+
+	// Verify DESC order (newest first)
+	if page1[0].ID != "post-4" {
+		t.Errorf("Expected first post to be post-4 (newest), got %s", page1[0].ID)
+	}
+	if page1[1].ID != "post-3" {
+		t.Errorf("Expected second post to be post-3, got %s", page1[1].ID)
+	}
+
+	// Test pagination - second page
+	page2, _, err := repo.List(ctx, "user-1", 2, 2)
+	if err != nil {
+		t.Fatalf("Failed to list posts page 2: %v", err)
+	}
+
+	if len(page2) != 1 {
+		t.Fatalf("Expected 1 post on page 2, got %d", len(page2))
+	}
+
+	if page2[0].ID != "post-1" {
+		t.Errorf("Expected post-1 on page 2, got %s", page2[0].ID)
+	}
+
+	// Test filtering by user-2
+	user2Posts, total2, err := repo.List(ctx, "user-2", 1, 10)
+	if err != nil {
+		t.Fatalf("Failed to list posts for user-2: %v", err)
+	}
+
+	if total2 != 1 {
+		t.Errorf("Expected total 1 for user-2, got %d", total2)
+	}
+
+	if len(user2Posts) != 1 || user2Posts[0].ID != "post-2" {
+		t.Errorf("Expected post-2 for user-2, got %v", user2Posts)
+	}
+}
+
+func TestYAMLPostRepository_GetByID_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "test_posts.yaml")
+
+	repo, err := NewYAMLPostRepository(yamlPath)
+	if err != nil {
+		t.Fatalf("Failed to create repository: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Try to get a non-existent post
+	_, err = repo.GetByID(ctx, "non-existent-id")
+	if err == nil {
+		t.Fatal("Expected error for non-existent post, got nil")
+	}
+
+	// Verify the error wraps os.ErrNotExist
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("Expected error to wrap os.ErrNotExist, got: %v", err)
+	}
+}
+
+func TestYAMLPostRepository_FileCreation(t *testing.T) {
+	tmpDir := t.TempDir()
+	yamlPath := filepath.Join(tmpDir, "subdir", "test_posts.yaml")
+
+	// Repository should create the directory if it doesn't exist
+	repo, err := NewYAMLPostRepository(yamlPath)
+	if err != nil {
+		t.Fatalf("Failed to create repository: %v", err)
+	}
+
+	// Verify the directory and file were created
+	if _, err := os.Stat(filepath.Dir(yamlPath)); os.IsNotExist(err) {
+		t.Fatal("Expected directory to be created")
+	}
+
+	if _, err := os.Stat(yamlPath); os.IsNotExist(err) {
+		t.Fatal("Expected YAML file to be created")
+	}
+
+	// Verify we can perform operations
+	ctx := context.Background()
+	posts, total, err := repo.List(ctx, "any-user", 1, 10)
+	if err != nil {
+		t.Fatalf("Failed to list posts: %v", err)
+	}
+
+	if total != 0 || len(posts) != 0 {
+		t.Errorf("Expected empty post list, got total=%d, len=%d", total, len(posts))
+	}
+}

--- a/services/be/main.go
+++ b/services/be/main.go
@@ -13,6 +13,7 @@ import (
 
 	"connectrpc.com/connect"
 	"connectrpc.com/validate"
+	postv1connect "github.com/poi2/building-a-schema-first-dynamic-validation-system/pkg/gen/go/post/v1/postv1connect"
 	userv1connect "github.com/poi2/building-a-schema-first-dynamic-validation-system/pkg/gen/go/user/v1/userv1connect"
 	"github.com/poi2/building-a-schema-first-dynamic-validation-system/services/be/internal/handler"
 	"github.com/poi2/building-a-schema-first-dynamic-validation-system/services/be/internal/repository"
@@ -33,22 +34,30 @@ func run() error {
 		port = "50052"
 	}
 
-	// YAML file path for user data
+	// YAML file paths for data
 	dataDir := os.Getenv("CELO_DATA_DIR")
 	if dataDir == "" {
 		dataDir = "./data"
 	}
 	userYAMLPath := filepath.Join(dataDir, "user.yaml")
+	postYAMLPath := filepath.Join(dataDir, "post.yaml")
 
-	// Initialize YAML repository
+	// Initialize YAML repositories
 	userRepo, err := repository.NewYAMLUserRepository(userYAMLPath)
 	if err != nil {
 		return fmt.Errorf("failed to initialize user repository: %w", err)
 	}
 	log.Printf("Initialized YAML user repository at %s", userYAMLPath)
 
-	// Initialize handler with YAML repository
+	postRepo, err := repository.NewYAMLPostRepository(postYAMLPath)
+	if err != nil {
+		return fmt.Errorf("failed to initialize post repository: %w", err)
+	}
+	log.Printf("Initialized YAML post repository at %s", postYAMLPath)
+
+	// Initialize handlers with YAML repositories
 	userHandler := handler.NewUserHandler(userRepo)
+	postHandler := handler.NewPostHandler(postRepo, userRepo)
 
 	// Create HTTP server with Connect
 	mux := http.NewServeMux()
@@ -56,8 +65,14 @@ func run() error {
 	interceptors := connect.WithInterceptors(
 		validate.NewInterceptor(),
 	)
-	path, connectHandler := userv1connect.NewUserServiceHandler(userHandler, interceptors)
-	mux.Handle(path, connectHandler)
+
+	// Register User Service
+	userPath, userConnectHandler := userv1connect.NewUserServiceHandler(userHandler, interceptors)
+	mux.Handle(userPath, userConnectHandler)
+
+	// Register Post Service
+	postPath, postConnectHandler := postv1connect.NewPostServiceHandler(postHandler, interceptors)
+	mux.Handle(postPath, postConnectHandler)
 
 	// Add health check endpoint
 	mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## 概要

Post APIを実装し、Context Enrichment（user.planを使った動的バリデーション）を実現しました。

## 実装内容

### 1. Postモデルとリポジトリ
- `model/post.go`: Postエンティティ（id, user_id, title, content, timestamps）
- `repository/yaml_post_repository.go`: YAMLファイルベースの永続化
  - 原子的書き込み（一時ファイル + rename）
  - ユーザーIDでのフィルタリング
  - ページネーション（新しい順）
  - エラーハンドリング（os.ErrNotExist）

### 2. PostHandler（Context Enrichment）
- **CreatePost**: Context Enrichmentの核心機能
  1. user_idからUserを取得
  2. User.Planを取得
  3. Plan に応じて content 長を動的に検証
     - FREE: 1000文字
     - PRO: 5000文字
     - ENTERPRISE: 10000文字
  4. バリデーションエラーの場合は適切なエラーを返す
  5. Postを作成してYAMLに保存
  
- **ListPosts**: ユーザーIDでフィルタリングしたページネーション付き一覧

### 3. main.goの更新
- Post YAMLリポジトリの初期化（post.yaml）
- PostServiceの登録

### 4. テスト
- `yaml_post_repository_test.go`: リポジトリの包括的テスト
  - ファイル作成
  - CRUD操作
  - ユーザーIDフィルタリング
  - ページネーション
  - エラーハンドリング

## 動作確認

### FREEプランユーザー（1000文字制限）
```bash
# ユーザー作成
curl -X POST http://localhost:50052/user.v1.UserService/CreateUser \
  -H "Content-Type: application/json" \
  -d '{"name":"Free User","email":"free@example.com","plan":"USER_PLAN_FREE"}'

# 1000文字以内の投稿（成功）
curl -X POST http://localhost:50052/post.v1.PostService/CreatePost \
  -H "Content-Type: application/json" \
  -d '{"user_id":"<user-id>","title":"Test","content":"short content"}'

# 1001文字の投稿（エラー）
curl -X POST http://localhost:50052/post.v1.PostService/CreatePost \
  -H "Content-Type: application/json" \
  -d '{"user_id":"<user-id>","title":"Test","content":"<1001 chars>"}'
# -> {"code":"invalid_argument","message":"content exceeds plan limit..."}
```

### PROプランユーザー（5000文字制限）
```bash
# PROユーザー作成
curl -X POST http://localhost:50052/user.v1.UserService/CreateUser \
  -H "Content-Type: application/json" \
  -d '{"name":"Pro User","email":"pro@example.com","plan":"USER_PLAN_PRO"}'

# 3000文字の投稿（成功）
curl -X POST http://localhost:50052/post.v1.PostService/CreatePost \
  -H "Content-Type: application/json" \
  -d '{"user_id":"<user-id>","title":"Medium Post","content":"<3000 chars>"}'
# -> 成功、UserPlan: USER_PLAN_PRO が設定される
```

### 投稿一覧
```bash
curl -X POST http://localhost:50052/post.v1.PostService/ListPosts \
  -H "Content-Type: application/json" \
  -d '{"user_id":"<user-id>","page":1,"page_size":10}'
# -> ユーザーの投稿を新しい順に取得
```

## テスト結果

```
=== RUN   TestYAMLPostRepository_Create
--- PASS: TestYAMLPostRepository_Create (0.01s)
=== RUN   TestYAMLPostRepository_List
--- PASS: TestYAMLPostRepository_List (0.03s)
=== RUN   TestYAMLPostRepository_GetByID_NotFound
--- PASS: TestYAMLPostRepository_GetByID_NotFound (0.01s)
=== RUN   TestYAMLPostRepository_FileCreation
--- PASS: TestYAMLPostRepository_FileCreation (0.01s)
PASS
```

## YAMLファイル形式

`services/be/data/post.yaml`:
```yaml
posts:
    - id: 019c976f-8ede-79c4-8758-3e2a6fc738bb
      user_id: 019c976f-69ae-762a-b17e-3f41636d75c8
      title: My First Post
      content: This is a test post
      created_at: 2026-02-26T00:53:16.638641Z
      updated_at: 2026-02-26T00:53:16.638641Z
```

## Context Enrichment の実装詳細

1. **タイミング**: ハンドラー内でUser取得後、バリデーション前
2. **検証ロジック**: `getMaxContentLengthForPlan()` でプラン別の制限を取得
3. **エラーハンドリング**: ユーザーが存在しない場合は `CodeNotFound`、制限超過の場合は `CodeInvalidArgument`
4. **レスポンス**: PostにXUserPlanフィールドを付与して返す

## 関連Issue

Closes #18

## Acceptance Criteria

- [x] CreatePost, ListPosts が実装されていること
- [x] CreatePost 時に user.yaml から user.plan を取得し、plan に応じた content 長制限を適用すること
- [x] FREE: 1000文字、PRO: 5000文字、ENTERPRISE: 10000文字
- [x] `services/be/data/post.yaml` にデータが保存されること
- [x] curl でテストできること